### PR TITLE
refactor time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   - `changes/2` allows to fetch the changes of an invidual source record
 * Update Postgrex to 0.15.11 and drop local `Xid8` type
 
+### Changed
+
+* Moved top-level functions to nested modules `Transaction` and `Multi`
+* Made `table_pk` be `NULL` when `primary_key_columns` is an empty array
+* Default `primary_key_columns` to `["id"]`
+
 ## [0.1.0] - 2021-09-01
 
 * Initial release.

--- a/lib/carbonite.ex
+++ b/lib/carbonite.ex
@@ -11,74 +11,8 @@ defmodule Carbonite do
 
   @moduledoc since: "0.1.0"
 
-  alias Carbonite.Transaction
-  alias Ecto.Multi
-
-  @type prefix :: binary() | map()
-  @type meta :: map()
-
-  @type build_option :: {:meta, meta()}
-
-  @doc """
-  Builds a changeset for a new `Carbonite.Transaction`.
-  """
-  @spec transaction_changeset() :: Ecto.Changeset.t()
-  @spec transaction_changeset([build_option()]) :: Ecto.Changeset.t()
-  def transaction_changeset(opts \\ []) do
-    meta = Keyword.get(opts, :meta, %{})
-    meta = Map.merge(current_meta(), meta)
-
-    Ecto.Changeset.cast(%Transaction{}, %{meta: meta}, [:meta])
-  end
-
-  @type insert_option :: {:prefix, prefix()} | build_option()
-
-  @doc """
-  Adds an insert operation for a `Carbonite.Transaction` to an `Ecto.Multi`.
-  """
-  @spec insert(Multi.t()) :: Multi.t()
-  @spec insert(Multi.t(), [insert_option()]) :: Multi.t()
-  def insert(%Multi{} = multi, opts \\ []) do
-    insert_opts =
-      opts
-      |> Keyword.take([:prefix])
-      |> Keyword.put_new(:prefix, default_prefix())
-      |> Keyword.put_new(:returning, [:id])
-
-    Multi.insert(
-      multi,
-      :carbonite_transaction,
-      fn _state -> transaction_changeset(opts) end,
-      insert_opts
-    )
-  end
-
-  @meta_pdict_key :carbonite_meta
-
-  @doc """
-  Stores a piece of metadata in the process dictionary.
-
-  This can be useful in situations where you want to record a value at a system boundary (say,
-  the user's `account_id`) without having to pass it through to the database transaction.
-
-  Returns the currently stored metadata.
-  """
-  @spec put_meta(key :: any(), value :: any()) :: meta()
-  def put_meta(key, value) do
-    meta = Map.put(current_meta(), key, value)
-    Process.put(@meta_pdict_key, meta)
-    meta
-  end
-
-  @doc """
-  Returns the currently stored metadata.
-  """
-  @spec current_meta() :: meta()
-  def current_meta do
-    Process.get(@meta_pdict_key) || %{}
-  end
-
-  @doc false
+  @doc "Returns the default transaction log prefix."
+  @doc since: "0.1.0"
   @spec default_prefix() :: binary()
   def default_prefix, do: "carbonite_default"
 end

--- a/lib/carbonite/change.ex
+++ b/lib/carbonite/change.ex
@@ -13,6 +13,8 @@ defmodule Carbonite.Change do
   `DELETE` statements have the delete data in `data` while `changed` is again an empty list.
   """
 
+  @moduledoc since: "0.1.0"
+
   use Ecto.Schema
 
   @primary_key false
@@ -23,7 +25,7 @@ defmodule Carbonite.Change do
           op: :insert | :update | :delete,
           table_prefix: String.t(),
           table_name: String.t(),
-          table_pk: [String.t()],
+          table_pk: nil | [String.t()],
           data: nil | map(),
           changed: [String.t()],
           transaction: Ecto.Association.NotLoaded.t() | Carbonite.Transaction.t()

--- a/lib/carbonite/multi.ex
+++ b/lib/carbonite/multi.ex
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.Multi do
+  @moduledoc """
+  This module provides functions for dealing with transaction logs in the context of Ecto.Multi.
+  """
+
+  import Carbonite, only: [default_prefix: 0]
+  alias Carbonite.Transaction
+  alias Ecto.Multi
+
+  @type prefix :: binary() | atom()
+  @type params :: map()
+  @type insert_transaction_option :: {:carbonite_prefix, prefix()} | {:params, map()}
+
+  @doc """
+  Adds an insert operation for a `Carbonite.Transaction` to an `Ecto.Multi`.
+
+  ## Options
+
+  * `carbonite_prefix` defines the transaction log's schema, defaults to `"carbonite_default"`
+  * `params` map of params for the `Carbonite.Transaction` (e.g., `:meta`)
+  """
+  @doc since: "0.1.1"
+  @spec insert_transaction(Multi.t()) :: Multi.t()
+  @spec insert_transaction(Multi.t(), params()) :: Multi.t()
+  @spec insert_transaction(Multi.t(), params(), [insert_transaction_option()]) :: Multi.t()
+  def insert_transaction(%Multi{} = multi, params \\ %{}, opts \\ []) do
+    carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    Multi.insert(multi, :carbonite_transaction, fn _state -> Transaction.changeset(params) end,
+      prefix: carbonite_prefix,
+      returning: [:id]
+    )
+  end
+end

--- a/lib/carbonite/outbox.ex
+++ b/lib/carbonite/outbox.ex
@@ -6,6 +6,8 @@ defmodule Carbonite.Outbox do
   in order of insertion.
   """
 
+  @moduledoc since: "0.1.0"
+
   import Carbonite, only: [default_prefix: 0]
   import Ecto.Changeset, only: [change: 2]
   import Ecto.Query, only: [from: 2]

--- a/lib/carbonite/query.ex
+++ b/lib/carbonite/query.ex
@@ -5,6 +5,8 @@ defmodule Carbonite.Query do
   This module provides query functions for retrieving transaction logs from the database.
   """
 
+  @moduledoc since: "0.1.1"
+
   import Ecto.Query, only: [from: 2, preload: 2, put_query_prefix: 2]
   import Carbonite, only: [default_prefix: 0]
   alias Carbonite.{Change, Transaction}
@@ -53,6 +55,7 @@ defmodule Carbonite.Query do
   * `carbonite_prefix` defines the transaction log's schema, defaults to `"carbonite_default"`
   * `preload` can be used to preload the changes
   """
+  @doc since: "0.1.1"
   @spec current_transaction() :: Ecto.Query.t()
   @spec current_transaction([current_transaction_option()]) :: Ecto.Query.t()
   def current_transaction(opts \\ []) do
@@ -79,6 +82,7 @@ defmodule Carbonite.Query do
   * `carbonite_prefix` defines the transaction log's schema, defaults to `"carbonite_default"`
   * `preload` can be used to preload the transaction
   """
+  @doc since: "0.1.1"
   @spec changes(Ecto.Schema.t()) :: Ecto.Query.t()
   @spec changes(Ecto.Schema.t(), [changes_option()]) :: Ecto.Query.t()
   def changes(%schema{__meta__: %Ecto.Schema.Metadata{}} = record, opts \\ []) do

--- a/lib/carbonite/transaction.ex
+++ b/lib/carbonite/transaction.ex
@@ -7,14 +7,19 @@ defmodule Carbonite.Transaction do
   As such, it contains a set of optional metadata that describes the transaction.
   """
 
+  @moduledoc since: "0.1.0"
+
   use Ecto.Schema
+  import Ecto.Changeset
 
   @primary_key false
   @timestamps_opts [type: :utc_datetime_usec]
 
+  @type meta :: map()
+
   @type t :: %__MODULE__{
           id: non_neg_integer(),
-          meta: map(),
+          meta: meta(),
           processed_at: DateTime.t(),
           inserted_at: DateTime.t(),
           changes: Ecto.Association.NotLoaded.t() | [Carbonite.Change.t()]
@@ -22,11 +27,59 @@ defmodule Carbonite.Transaction do
 
   schema "transactions" do
     field(:id, :integer, primary_key: true)
-    field(:meta, :map)
+    field(:meta, :map, default: %{})
     field(:processed_at, :utc_datetime_usec)
 
     timestamps(updated_at: false)
 
     has_many(:changes, Carbonite.Change, references: :id)
+  end
+
+  @meta_pdict_key :carbonite_meta
+
+  @doc """
+  Stores a piece of metadata in the process dictionary.
+
+  This can be useful in situations where you want to record a value at a system boundary (say,
+  the user's `account_id`) without having to pass it through to the database transaction.
+
+  Returns the currently stored metadata.
+  """
+  @doc since: "0.1.1"
+  @spec put_meta(key :: any(), value :: any()) :: meta()
+  def put_meta(key, value) do
+    meta = Map.put(current_meta(), key, value)
+    Process.put(@meta_pdict_key, meta)
+    meta
+  end
+
+  @doc """
+  Returns the currently stored metadata.
+  """
+  @doc since: "0.1.1"
+  @spec current_meta() :: meta()
+  def current_meta do
+    Process.get(@meta_pdict_key) || %{}
+  end
+
+  @doc """
+  Builds a changeset for a new `Carbonite.Transaction`.
+
+  The `:meta` map from the params will be merged with the metadata currently stored in the
+  process dictionary.
+  """
+  @doc since: "0.1.1"
+  @spec changeset() :: Ecto.Changeset.t()
+  @spec changeset(params :: map()) :: Ecto.Changeset.t()
+  def changeset(params \\ %{}) do
+    %__MODULE__{}
+    |> cast(params, [:meta])
+    |> merge_current_meta()
+  end
+
+  defp merge_current_meta(changeset) do
+    meta = Map.merge(current_meta(), get_field(changeset, :meta))
+
+    put_change(changeset, :meta, meta)
   end
 end

--- a/lib/carbonite/trigger.ex
+++ b/lib/carbonite/trigger.ex
@@ -5,6 +5,8 @@ defmodule Carbonite.Trigger do
   A `Carbonite.Trigger` stores per table configuration for the change capture trigger.
   """
 
+  @moduledoc since: "0.1.0"
+
   use Ecto.Schema
 
   @primary_key {:id, :id, autogenerate: true}

--- a/test/capture_test.exs
+++ b/test/capture_test.exs
@@ -151,6 +151,17 @@ defmodule CaptureTest do
              ] = select_changes()
     end
 
+    test "table_pk is NULL when primary_key_columns is empty" do
+      query!("UPDATE carbonite_default.triggers SET primary_key_columns = '{}';")
+
+      TestRepo.transaction(fn ->
+        insert_transaction()
+        insert_jack()
+      end)
+
+      assert [%{"table_pk" => nil}] = select_changes()
+    end
+
     test "a friendly error is raised when transaction is not inserted or is inserted too late" do
       msg =
         "ERROR 23503 (foreign_key_violation) INSERT on table public.rabbits " <>

--- a/test/carbonite/query_test.exs
+++ b/test/carbonite/query_test.exs
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-defmodule QuertTest do
+defmodule Carbonite.QueryTest do
   use ExUnit.Case, async: true
   import Ecto.Query, only: [from: 2]
   alias Carbonite.{Change, Query, Rabbit, TestRepo, Transaction}
@@ -13,7 +13,7 @@ defmodule QuertTest do
   defp insert_rabbits(_ \\ nil) do
     {:ok, results} =
       Ecto.Multi.new()
-      |> Carbonite.insert()
+      |> Carbonite.Multi.insert_transaction()
       |> Ecto.Multi.put(:params, %{name: "Jack", age: 99})
       |> Ecto.Multi.insert(:rabbit, &Rabbit.create_changeset(&1.params))
       |> Ecto.Multi.put(:params2, %{name: "Lily", age: 172})

--- a/test/carbonite/transaction_test.exs
+++ b/test/carbonite/transaction_test.exs
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.TransactionTest do
+  use ExUnit.Case, async: true
+  import Carbonite.Transaction
+  import Ecto.Changeset
+
+  describe "changeset/1" do
+    test "transaction_changesets an Ecto.Changeset for a transaction" do
+      %Ecto.Changeset{} = changeset = changeset()
+
+      assert get_field(changeset, :meta) == %{}
+    end
+
+    test "allows setting metadata" do
+      %Ecto.Changeset{} = changeset = changeset(%{meta: %{foo: 1}})
+
+      assert get_field(changeset, :meta) == %{foo: 1}
+    end
+
+    test "merges metadata from process dictionary" do
+      put_meta(:foo, 1)
+      put_meta(:bar, 1)
+      %Ecto.Changeset{} = changeset = changeset(%{meta: %{foo: 2}})
+
+      assert get_field(changeset, :meta) == %{foo: 2, bar: 1}
+    end
+  end
+end

--- a/test/support/rabbit.ex
+++ b/test/support/rabbit.ex
@@ -26,7 +26,7 @@ defmodule Carbonite.Rabbit do
   # Dirty little helper to make rabbits on the console.
   def make do
     Ecto.Multi.new()
-    |> Carbonite.insert()
+    |> Carbonite.Multi.insert_transaction()
     |> Ecto.Multi.insert(:rabbit, fn _ -> create_changeset(%{age: 101, name: "Janet"}) end)
     |> Carbonite.TestRepo.transaction()
   end


### PR DESCRIPTION
- if `primary_key_columns` are empty, `table_pk` must be NULL to not pollute
  the index
- move top-level functions to new modules `Transaction`, `Multi`
- docs updates
- default `primary_key_columns` to `[:id]`