### PR TITLE
Feature/17 schema doesn t drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ### Added
 
-* `Carbonite.Migration.drop_tables/1` allows to drop the carbonite audit trail without removing the schema
+* `Carbonite.Migrations.drop_tables/1` allows to drop the carbonite audit trail without removing the schema
+
+### Changed
+
+* Renamed the option that can be passed to `Carbonite.Migrations.drop_schema/1` from `prefix` to `carbonite_prefix`
+* Changed `Carbonite.Migrations.drop_schema/1` to also drop the tables
 
 ### Fixed
 
 * Fixed ignore mode when override_transaction_id is NULL
-
-### Changed
-
-* Renamed the option that can be passed to `Carbonite.Migration.drop_schema/1` from `prefix` to `carbonite_prefix`
 
 ## [0.2.1] - 2021-10-10
 

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -238,6 +238,7 @@ defmodule Carbonite.Migrations do
   @spec drop_schema() :: :ok
   @spec drop_schema([schema_option()]) :: :ok
   def drop_schema(opts \\ []) when is_list(opts) do
+    drop_tables(opts)
     prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
 
     execute("DROP SCHEMA #{prefix};")


### PR DESCRIPTION
Now calls `drop_tables/1` before dropping the schema.