### PR TITLE
Fix carbonite prefix handling

### DIFF
--- a/lib/carbonite/query.ex
+++ b/lib/carbonite/query.ex
@@ -41,7 +41,7 @@ defmodule Carbonite.Query do
   @spec transactions() :: Ecto.Query.t()
   @spec transactions([transactions_option()]) :: Ecto.Query.t()
   def transactions(opts \\ []) do
-    carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+    carbonite_prefix = get_carbonite_prefix(opts)
 
     from(t in Transaction)
     |> put_query_prefix(carbonite_prefix)
@@ -83,7 +83,7 @@ defmodule Carbonite.Query do
   @spec current_transaction() :: Ecto.Query.t()
   @spec current_transaction([current_transaction_option()]) :: Ecto.Query.t()
   def current_transaction(opts \\ []) do
-    carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+    carbonite_prefix = get_carbonite_prefix(opts)
 
     from(t in Transaction, where: t.id == fragment("pg_current_xact_id()"))
     |> put_query_prefix(carbonite_prefix)
@@ -118,7 +118,7 @@ defmodule Carbonite.Query do
   @spec changes(record :: Ecto.Schema.t()) :: Ecto.Query.t()
   @spec changes(record :: Ecto.Schema.t(), [changes_option()]) :: Ecto.Query.t()
   def changes(%schema{__meta__: %Ecto.Schema.Metadata{}} = record, opts \\ []) do
-    carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+    carbonite_prefix = get_carbonite_prefix(opts)
 
     table_prefix =
       Keyword.get_lazy(opts, :table_prefix, fn ->
@@ -147,5 +147,11 @@ defmodule Carbonite.Query do
       true -> preload(queryable, ^default)
       preload -> preload(queryable, ^preload)
     end
+  end
+
+  defp get_carbonite_prefix(opts) do
+    opts
+    |> Keyword.get(:carbonite_prefix, default_prefix())
+    |> to_string()
   end
 end

--- a/test/carbonite/query_test.exs
+++ b/test/carbonite/query_test.exs
@@ -47,6 +47,18 @@ defmodule Carbonite.QueryTest do
 
       assert [%Transaction{changes: []} | _] = TestRepo.all(Query.transactions(preload: true))
     end
+
+    test "can use atom as prefix" do
+      prefix =
+        Carbonite.default_prefix()
+        |> String.to_atom()
+
+      result =
+        Query.transactions(carbonite_prefix: prefix)
+        |> TestRepo.all()
+
+      assert length(result) == 3
+    end
   end
 
   describe "current_transaction/2" do


### PR DESCRIPTION
The specification of the type `Carbonite.Query.prefix` allows `atom()` as prefix but `Ecto.Query.put_query_prefix/2` only accepts `String.t()`. Converting the given carbonite prefix to `String.t()`.