### PR TITLE
migration fixups

### DIFF
--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -108,11 +108,13 @@ defmodule Carbonite.Migrations do
 
     """
     INSERT INTO #{carbonite_prefix}.triggers (
+      id,
       table_prefix,
       table_name,
       inserted_at,
       updated_at
     ) VALUES (
+      NEXTVAL('#{carbonite_prefix}.triggers_id_seq'),
       '#{table_prefix}',
       '#{table_name}',
       NOW(),
@@ -192,7 +194,7 @@ defmodule Carbonite.Migrations do
   end
 
   def put_trigger_config(table_name, :mode, value, opts) when value in [:capture, :ignore] do
-    do_put_trigger_config(table_name, :mode, value, opts)
+    do_put_trigger_config(table_name, :mode, "'#{value}'", opts)
   end
 
   defp do_put_trigger_config(table_name, field, value, opts) do

--- a/lib/carbonite/migrations/v1.ex
+++ b/lib/carbonite/migrations/v1.ex
@@ -61,7 +61,9 @@ defmodule Carbonite.Migrations.V1 do
 
     execute("CREATE TYPE #{prefix}.change_op AS ENUM('insert', 'update', 'delete');")
 
-    create table("changes", prefix: prefix) do
+    create table("changes", primary_key: false, prefix: prefix) do
+      add(:id, :bigserial, null: false, primary_key: true)
+
       add(
         :transaction_id,
         references(:transactions,
@@ -88,7 +90,8 @@ defmodule Carbonite.Migrations.V1 do
 
     execute("CREATE TYPE #{prefix}.trigger_mode AS ENUM('capture', 'ignore');")
 
-    create table("triggers", prefix: prefix) do
+    create table("triggers", primary_key: false, prefix: prefix) do
+      add(:id, :bigserial, null: false, primary_key: true)
       add(:table_prefix, :string, null: false)
       add(:table_name, :string, null: false)
       add(:primary_key_columns, {:array, :string}, null: false)


### PR DESCRIPTION
* set id explicitly in `create_trigger/2`
* restore bigserial `id` PKs on triggers & changes
* quote `mode` value in `put_trigger_config/4`