### PR TITLE
[#45] Transaction ID not stable across Postgres installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**New migration patches:** 4
+
+### Switch to normal identity column on `transactions`
+
+* The `id` column on `transactions` has been replaced with an ordinary autoincrementing integer PK, filled from a sequence. Next to it a new `xact_id` column continues to store the transaction id (from `pg_current_xact_id`). Both values used together ensure that, first the `id` is monotonically increasing and survives a backup restore (see issue #45), and second the `changes` records can still only be inserted within the same transaction.
+
 ## [0.4.0] - 2021-11-07
 
 **New migration patches:** 2, 3

--- a/lib/carbonite.ex
+++ b/lib/carbonite.ex
@@ -100,7 +100,7 @@ defmodule Carbonite do
     carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
 
     from(t in Trigger,
-      update: [set: [override_transaction_id: fragment("pg_current_xact_id()")]]
+      update: [set: [override_xact_id: fragment("pg_current_xact_id()")]]
     )
     |> repo.update_all([], prefix: carbonite_prefix)
 

--- a/lib/carbonite/change.ex
+++ b/lib/carbonite/change.ex
@@ -35,7 +35,8 @@ defmodule Carbonite.Change do
           table_pk: nil | [String.t()],
           data: nil | map(),
           changed: [String.t()],
-          transaction: Ecto.Association.NotLoaded.t() | Carbonite.Transaction.t()
+          transaction: Ecto.Association.NotLoaded.t() | Carbonite.Transaction.t(),
+          transaction_xact_id: non_neg_integer()
         }
 
   schema "changes" do
@@ -48,5 +49,7 @@ defmodule Carbonite.Change do
     field(:changed, {:array, :string})
 
     belongs_to(:transaction, Carbonite.Transaction)
+
+    field(:transaction_xact_id, :integer)
   end
 end

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations do
   # --------------------------------- patch levels ---------------------------------
 
   @initial_patch 1
-  @current_patch 2
+  @current_patch 4
 
   @doc false
   @spec initial_patch :: non_neg_integer()
@@ -39,8 +39,8 @@ defmodule Carbonite.Migrations do
 
   Make sure that you run all migrations in your host application.
 
-  * Initial patch: 1
-  * Current patch: 2
+  * Initial patch: #{@initial_patch}
+  * Current patch: #{@current_patch}
 
   ## Options
 

--- a/lib/carbonite/migrations/v1.ex
+++ b/lib/carbonite/migrations/v1.ex
@@ -10,8 +10,8 @@ defmodule Carbonite.Migrations.V1 do
 
   @type up_option :: {:carbonite_prefix, prefix()}
 
-  @spec create_set_transaction_id(prefix()) :: :ok
-  def create_set_transaction_id(prefix) do
+  @spec create_set_transaction_id_procedure(prefix()) :: :ok
+  def create_set_transaction_id_procedure(prefix) do
     """
     CREATE OR REPLACE FUNCTION #{prefix}.set_transaction_id() RETURNS TRIGGER AS
     $body$
@@ -25,8 +25,8 @@ defmodule Carbonite.Migrations.V1 do
     |> squish_and_execute()
   end
 
-  @spec create_capture_changes(prefix()) :: :ok
-  def create_capture_changes(prefix) do
+  @spec create_capture_changes_procedure(prefix()) :: :ok
+  def create_capture_changes_procedure(prefix) do
     """
     CREATE OR REPLACE FUNCTION #{prefix}.capture_changes() RETURNS TRIGGER AS
     $body$
@@ -146,7 +146,7 @@ defmodule Carbonite.Migrations.V1 do
       )
     )
 
-    create_set_transaction_id(prefix)
+    create_set_transaction_id_procedure(prefix)
 
     """
     CREATE TRIGGER set_transaction_id_trigger
@@ -220,7 +220,7 @@ defmodule Carbonite.Migrations.V1 do
 
     # ------------- Capture Function -------------
 
-    create_capture_changes(prefix)
+    create_capture_changes_procedure(prefix)
 
     :ok
   end

--- a/lib/carbonite/migrations/v1.ex
+++ b/lib/carbonite/migrations/v1.ex
@@ -10,34 +10,10 @@ defmodule Carbonite.Migrations.V1 do
 
   @type up_option :: {:carbonite_prefix, prefix()}
 
-  @impl true
-  @spec up([up_option()]) :: :ok
-  def up(opts) do
-    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
-
-    # ---------------- Schema --------------------
-
-    execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
-
-    # -------------- Transactions ----------------
-
-    create table("transactions", primary_key: false, prefix: prefix) do
-      add(:id, :xid8, null: false, primary_key: true)
-      add(:meta, :map, null: false, default: %{})
-      add(:processed_at, :utc_datetime_usec)
-
-      timestamps(updated_at: false, type: :utc_datetime_usec)
-    end
-
-    create(
-      index("transactions", [:inserted_at],
-        where: "processed_at IS NULL",
-        prefix: prefix
-      )
-    )
-
+  @spec create_set_transaction_id(prefix()) :: :ok
+  def create_set_transaction_id(prefix) do
     """
-    CREATE FUNCTION #{prefix}.set_transaction_id() RETURNS TRIGGER AS
+    CREATE OR REPLACE FUNCTION #{prefix}.set_transaction_id() RETURNS TRIGGER AS
     $body$
     BEGIN
       NEW.id = COALESCE(NEW.id, pg_current_xact_id());
@@ -47,81 +23,12 @@ defmodule Carbonite.Migrations.V1 do
     LANGUAGE plpgsql;
     """
     |> squish_and_execute()
+  end
 
+  @spec create_capture_changes(prefix()) :: :ok
+  def create_capture_changes(prefix) do
     """
-    CREATE TRIGGER set_transaction_id_trigger
-    BEFORE INSERT
-    ON #{prefix}.transactions
-    FOR EACH ROW
-    EXECUTE PROCEDURE #{prefix}.set_transaction_id();
-    """
-    |> squish_and_execute()
-
-    # ---------------- Changes -------------------
-
-    execute("CREATE TYPE #{prefix}.change_op AS ENUM('insert', 'update', 'delete');")
-
-    create table("changes", primary_key: false, prefix: prefix) do
-      add(:id, :bigserial, null: false, primary_key: true)
-
-      add(
-        :transaction_id,
-        references(:transactions,
-          on_delete: :delete_all,
-          on_update: :update_all,
-          type: :xid8,
-          prefix: prefix
-        ),
-        null: false
-      )
-
-      add(:op, :"#{prefix}.change_op", null: false)
-      add(:table_prefix, :string, null: false)
-      add(:table_name, :string, null: false)
-      add(:table_pk, {:array, :string}, null: true)
-      add(:data, :jsonb, null: false)
-      add(:changed, {:array, :string}, null: false)
-    end
-
-    create(index("changes", [:transaction_id], prefix: prefix))
-    create(index("changes", [:table_prefix, :table_name, :table_pk], prefix: prefix))
-
-    # ---------------- Triggers ------------------
-
-    execute("CREATE TYPE #{prefix}.trigger_mode AS ENUM('capture', 'ignore');")
-
-    create table("triggers", primary_key: false, prefix: prefix) do
-      add(:id, :bigserial, null: false, primary_key: true)
-      add(:table_prefix, :string, null: false)
-      add(:table_name, :string, null: false)
-      add(:primary_key_columns, {:array, :string}, null: false)
-      add(:excluded_columns, {:array, :string}, null: false)
-      add(:filtered_columns, {:array, :string}, null: false)
-      add(:mode, :"#{prefix}.trigger_mode", null: false)
-      add(:override_transaction_id, :xid8, null: true)
-
-      timestamps()
-    end
-
-    create(
-      index("triggers", [:table_prefix, :table_name],
-        name: "table_index",
-        unique: true,
-        include: [
-          :primary_key_columns,
-          :excluded_columns,
-          :filtered_columns,
-          :mode,
-          :override_transaction_id
-        ],
-        prefix: prefix
-      )
-    )
-
-    # ------------- Capture Function -------------
-
-    """
-    CREATE FUNCTION #{prefix}.capture_changes() RETURNS TRIGGER AS
+    CREATE OR REPLACE FUNCTION #{prefix}.capture_changes() RETURNS TRIGGER AS
     $body$
     DECLARE
       trigger_row #{prefix}.triggers;
@@ -211,6 +118,109 @@ defmodule Carbonite.Migrations.V1 do
     LANGUAGE plpgsql;
     """
     |> squish_and_execute()
+  end
+
+  @impl true
+  @spec up([up_option()]) :: :ok
+  def up(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    # ---------------- Schema --------------------
+
+    execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
+
+    # -------------- Transactions ----------------
+
+    create table("transactions", primary_key: false, prefix: prefix) do
+      add(:id, :xid8, null: false, primary_key: true)
+      add(:meta, :map, null: false, default: %{})
+      add(:processed_at, :utc_datetime_usec)
+
+      timestamps(updated_at: false, type: :utc_datetime_usec)
+    end
+
+    create(
+      index("transactions", [:inserted_at],
+        where: "processed_at IS NULL",
+        prefix: prefix
+      )
+    )
+
+    create_set_transaction_id(prefix)
+
+    """
+    CREATE TRIGGER set_transaction_id_trigger
+    BEFORE INSERT
+    ON #{prefix}.transactions
+    FOR EACH ROW
+    EXECUTE PROCEDURE #{prefix}.set_transaction_id();
+    """
+    |> squish_and_execute()
+
+    # ---------------- Changes -------------------
+
+    execute("CREATE TYPE #{prefix}.change_op AS ENUM('insert', 'update', 'delete');")
+
+    create table("changes", primary_key: false, prefix: prefix) do
+      add(:id, :bigserial, null: false, primary_key: true)
+
+      add(
+        :transaction_id,
+        references(:transactions,
+          on_delete: :delete_all,
+          on_update: :update_all,
+          type: :xid8,
+          prefix: prefix
+        ),
+        null: false
+      )
+
+      add(:op, :"#{prefix}.change_op", null: false)
+      add(:table_prefix, :string, null: false)
+      add(:table_name, :string, null: false)
+      add(:table_pk, {:array, :string}, null: true)
+      add(:data, :jsonb, null: false)
+      add(:changed, {:array, :string}, null: false)
+    end
+
+    create(index("changes", [:transaction_id], prefix: prefix))
+    create(index("changes", [:table_prefix, :table_name, :table_pk], prefix: prefix))
+
+    # ---------------- Triggers ------------------
+
+    execute("CREATE TYPE #{prefix}.trigger_mode AS ENUM('capture', 'ignore');")
+
+    create table("triggers", primary_key: false, prefix: prefix) do
+      add(:id, :bigserial, null: false, primary_key: true)
+      add(:table_prefix, :string, null: false)
+      add(:table_name, :string, null: false)
+      add(:primary_key_columns, {:array, :string}, null: false)
+      add(:excluded_columns, {:array, :string}, null: false)
+      add(:filtered_columns, {:array, :string}, null: false)
+      add(:mode, :"#{prefix}.trigger_mode", null: false)
+      add(:override_transaction_id, :xid8, null: true)
+
+      timestamps()
+    end
+
+    create(
+      index("triggers", [:table_prefix, :table_name],
+        name: "table_index",
+        unique: true,
+        include: [
+          :primary_key_columns,
+          :excluded_columns,
+          :filtered_columns,
+          :mode,
+          :override_transaction_id
+        ],
+        prefix: prefix
+      )
+    )
+
+    # ------------- Capture Function -------------
+
+    create_capture_changes(prefix)
 
     :ok
   end

--- a/lib/carbonite/migrations/v3.ex
+++ b/lib/carbonite/migrations/v3.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations.V3 do
     create table("outboxes", primary_key: false, prefix: prefix) do
       add(:name, :string, null: false, primary_key: true)
       add(:memo, :map, null: false, default: "{}")
-      add(:last_transaction_id, :xid8, null: false, default: "0::xid8")
+      add(:last_transaction_id, :xid8, null: false, default: "0::TEXT::xid8")
 
       timestamps(type: :utc_datetime_usec)
     end

--- a/lib/carbonite/migrations/v4.ex
+++ b/lib/carbonite/migrations/v4.ex
@@ -223,8 +223,8 @@ defmodule Carbonite.Migrations.V4 do
 
     # ------------ Restore functions -------------
 
-    V1.create_set_transaction_id(prefix)
-    V1.create_capture_changes(prefix)
+    V1.create_set_transaction_id_procedure(prefix)
+    V1.create_capture_changes_procedure(prefix)
 
     :ok
   end

--- a/lib/carbonite/migrations/v4.ex
+++ b/lib/carbonite/migrations/v4.ex
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.Migrations.V4 do
+  @moduledoc false
+
+  use Ecto.Migration
+  use Carbonite.Migrations.Version
+  alias Carbonite.Migrations.V1
+
+  @type prefix :: binary()
+
+  @type up_option :: {:carbonite_prefix, prefix()}
+
+  # This buffer ensures that the sequence is initialized to a value hopefully greater than the
+  # current xact id, even if new `transactions` records have been inserted during the migration.
+  @xact_id_buffer 5000
+
+  @impl true
+  @spec up([up_option()]) :: :ok
+  def up(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    lock_changes(prefix)
+
+    # ------------- Change constraints -----------
+
+    temporarily_drop_fk_on_changes(prefix, fn ->
+      rename_id_column(prefix, "transactions", :id, :xact_id)
+      rename_id_column(prefix, "changes", :transaction_id, :transaction_xact_id)
+
+      squish_and_execute("ALTER TABLE #{prefix}.transactions DROP CONSTRAINT transactions_pkey;")
+
+      squish_and_execute(
+        "ALTER TABLE #{prefix}.transactions ADD PRIMARY KEY (id) INCLUDE (xact_id);"
+      )
+    end)
+
+    temporarily_drop_default_on_outboxes(prefix, "0", fn ->
+      change_type(prefix, "outboxes", "last_transaction_id", "BIGINT")
+    end)
+
+    # ------------- New ID sequence --------------
+
+    %Postgrex.Result{rows: [[seq_start_with]]} =
+      repo().query!("SELECT pg_current_xact_id()::TEXT::BIGINT + #{@xact_id_buffer};")
+
+    """
+    CREATE SEQUENCE #{prefix}.transactions_id_seq
+    START WITH #{seq_start_with}
+    OWNED BY #{prefix}.transactions.id;
+    """
+    |> squish_and_execute()
+
+    """
+    CREATE OR REPLACE FUNCTION #{prefix}.set_transaction_id() RETURNS TRIGGER AS
+    $body$
+    BEGIN
+      BEGIN
+        /* verify that no previous INSERT within current transaction (with same id) */
+        IF
+          EXISTS(
+            SELECT 1 FROM #{prefix}.transactions
+            WHERE id = COALESCE(NEW.id, CURRVAL('#{prefix}.transactions_id_seq'))
+            AND xact_id = COALESCE(NEW.xact_id, pg_current_xact_id())
+          )
+        THEN
+          NEW.id = COALESCE(NEW.id, CURRVAL('#{prefix}.transactions_id_seq'));
+        END IF;
+      EXCEPTION WHEN object_not_in_prerequisite_state THEN
+        /* when NEXTVAL has never been called within session, we're good */
+      END;
+
+      NEW.id = COALESCE(NEW.id, NEXTVAL('#{prefix}.transactions_id_seq'));
+      NEW.xact_id = COALESCE(NEW.xact_id, pg_current_xact_id());
+
+      RETURN NEW;
+    END
+    $body$
+    LANGUAGE plpgsql;
+    """
+    |> squish_and_execute()
+
+    # ------------- override_xact_id -------------
+
+    rename(table("triggers", prefix: prefix), :override_transaction_id, to: :override_xact_id)
+
+    # ------------- Capture Function -------------
+
+    """
+    CREATE OR REPLACE FUNCTION #{prefix}.capture_changes() RETURNS TRIGGER AS
+    $body$
+    DECLARE
+      trigger_row #{prefix}.triggers;
+      change_row #{prefix}.changes;
+      pk_source RECORD;
+      col_name VARCHAR;
+      pk_col_val VARCHAR;
+      old_field RECORD;
+    BEGIN
+      /* load trigger config */
+      SELECT *
+        INTO trigger_row
+        FROM #{prefix}.triggers
+        WHERE table_prefix = TG_TABLE_SCHEMA AND table_name = TG_TABLE_NAME;
+
+      IF
+        (trigger_row.mode = 'ignore' AND (trigger_row.override_xact_id IS NULL OR trigger_row.override_xact_id != pg_current_xact_id())) OR
+        (trigger_row.mode = 'capture' AND trigger_row.override_xact_id = pg_current_xact_id())
+      THEN
+        RETURN NULL;
+      END IF;
+
+      /* instantiate change row */
+      change_row = ROW(
+        NEXTVAL('#{prefix}.changes_id_seq'),
+        pg_current_xact_id(),
+        LOWER(TG_OP::TEXT),
+        TG_TABLE_SCHEMA::TEXT,
+        TG_TABLE_NAME::TEXT,
+        NULL,
+        NULL,
+        '{}',
+        NULL
+      );
+
+      /* build table_pk */
+      IF trigger_row.primary_key_columns != '{}' THEN
+        IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+          pk_source := NEW;
+        ELSIF (TG_OP = 'DELETE') THEN
+          pk_source := OLD;
+        END IF;
+
+        change_row.table_pk := '{}';
+
+        FOREACH col_name IN ARRAY trigger_row.primary_key_columns LOOP
+          EXECUTE 'SELECT $1.' || col_name || '::TEXT' USING pk_source INTO pk_col_val;
+          change_row.table_pk := change_row.table_pk || pk_col_val;
+        END LOOP;
+      END IF;
+
+      /* fill in changed data */
+      IF (TG_OP = 'UPDATE') THEN
+        change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
+
+        FOR old_field IN SELECT * FROM jsonb_each(to_jsonb(OLD.*) - trigger_row.excluded_columns) LOOP
+          IF NOT change_row.data @> jsonb_build_object(old_field.key, old_field.value)
+             THEN change_row.changed := change_row.changed || old_field.key::VARCHAR;
+          END IF;
+        END LOOP;
+
+        IF change_row.changed = '{}' THEN
+          /* All changed fields are ignored. Skip this update. */
+          RETURN NULL;
+        END IF;
+      ELSIF (TG_OP = 'DELETE') THEN
+        change_row.data = to_jsonb(OLD.*) - trigger_row.excluded_columns;
+      ELSIF (TG_OP = 'INSERT') THEN
+        change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
+      END IF;
+
+      /* filtered columns */
+      FOREACH col_name IN ARRAY trigger_row.filtered_columns LOOP
+        change_row.data = jsonb_set(change_row.data, ('{' || col_name || '}')::TEXT[], jsonb('"[FILTERED]"'));
+      END LOOP;
+
+      /* insert, fail gracefully unless transaction record present or NEXTVAL has never been called */
+      BEGIN
+        change_row.transaction_id = CURRVAL('#{prefix}.transactions_id_seq');
+
+        /* verify that xact_id matches */
+        IF NOT
+          EXISTS(
+            SELECT 1 FROM #{prefix}.transactions
+            WHERE id = change_row.transaction_id AND xact_id = change_row.transaction_xact_id
+          )
+        THEN
+          RAISE USING ERRCODE = 'foreign_key_violation';
+        END IF;
+
+        INSERT INTO #{prefix}.changes VALUES (change_row.*);
+      EXCEPTION WHEN foreign_key_violation OR object_not_in_prerequisite_state THEN
+          RAISE '% on table %.% without prior INSERT into #{prefix}.transactions',
+            TG_OP, TG_TABLE_SCHEMA, TG_TABLE_NAME USING ERRCODE = 'foreign_key_violation';
+      END;
+
+      RETURN NULL;
+    END;
+    $body$
+    LANGUAGE plpgsql;
+    """
+    |> squish_and_execute()
+
+    :ok
+  end
+
+  @type down_option :: {:carbonite_prefix, prefix()}
+
+  @impl true
+  @spec down([down_option()]) :: :ok
+  def down(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    lock_changes(prefix)
+
+    # ------------- Change constraints -----------
+
+    temporarily_drop_fk_on_changes(prefix, fn ->
+      squish_and_execute("ALTER TABLE #{prefix}.transactions DROP CONSTRAINT transactions_pkey;")
+      squish_and_execute("ALTER TABLE #{prefix}.transactions ADD PRIMARY KEY (xact_id);")
+
+      revert_id_column(prefix, "changes", :transaction_xact_id, :transaction_id)
+      revert_id_column(prefix, "transactions", :xact_id, :id)
+    end)
+
+    temporarily_drop_default_on_outboxes(prefix, "0", fn ->
+      change_type(prefix, "outboxes", "last_transaction_id", "BIGINT")
+    end)
+
+    # ------------- override_xact_id -------------
+
+    rename(table("triggers", prefix: prefix), :override_xact_id, to: :override_transaction_id)
+
+    # ------------ Restore functions -------------
+
+    V1.create_set_transaction_id(prefix)
+    V1.create_capture_changes(prefix)
+
+    :ok
+  end
+
+  defp lock_changes(prefix) do
+    squish_and_execute("LOCK TABLE #{prefix}.changes IN EXCLUSIVE MODE;")
+  end
+
+  defp rename_id_column(prefix, table, from, to) do
+    rename(table(table, prefix: prefix), from, to: to)
+
+    alter table(table, prefix: prefix) do
+      add(from, :bigint, null: true)
+    end
+
+    squish_and_execute("UPDATE #{prefix}.#{table} SET #{from} = #{to}::TEXT::BIGINT;")
+
+    alter table(table, prefix: prefix) do
+      modify(from, :bigint, null: false)
+    end
+  end
+
+  defp revert_id_column(prefix, table, from, to) do
+    alter table(table, prefix: prefix) do
+      remove(to)
+    end
+
+    rename(table(table, prefix: prefix), from, to: to)
+  end
+
+  defp change_type(prefix, table, column, type) do
+    """
+    ALTER TABLE #{prefix}.#{table}
+    ALTER COLUMN #{column}
+    SET DATA TYPE #{type}
+    USING #{column}::text::#{type};
+    """
+    |> squish_and_execute()
+  end
+
+  defp temporarily_drop_fk_on_changes(prefix, callback) do
+    """
+    ALTER TABLE #{prefix}.changes
+    DROP CONSTRAINT changes_transaction_id_fkey;
+    """
+    |> squish_and_execute()
+
+    callback.()
+
+    """
+    ALTER TABLE #{prefix}.changes
+    ADD CONSTRAINT changes_transaction_id_fkey
+    FOREIGN KEY (transaction_id)
+    REFERENCES #{prefix}.transactions
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+    """
+    |> squish_and_execute()
+  end
+
+  defp temporarily_drop_default_on_outboxes(prefix, default, callback) do
+    """
+    ALTER TABLE #{prefix}.outboxes
+    ALTER COLUMN last_transaction_id
+    DROP DEFAULT;
+    """
+    |> squish_and_execute()
+
+    callback.()
+
+    """
+    ALTER TABLE #{prefix}.outboxes
+    ALTER COLUMN last_transaction_id
+    SET DEFAULT #{default};
+    """
+    |> squish_and_execute()
+  end
+end

--- a/lib/carbonite/transaction.ex
+++ b/lib/carbonite/transaction.ex
@@ -25,6 +25,7 @@ defmodule Carbonite.Transaction do
 
   @type t :: %__MODULE__{
           id: id(),
+          xact_id: non_neg_integer(),
           meta: meta(),
           inserted_at: DateTime.t(),
           changes: Ecto.Association.NotLoaded.t() | [Carbonite.Change.t()]
@@ -32,6 +33,7 @@ defmodule Carbonite.Transaction do
 
   schema "transactions" do
     field(:id, :integer, primary_key: true)
+    field(:xact_id, :integer)
     field(:meta, :map, default: %{})
 
     timestamps(updated_at: false)

--- a/lib/carbonite/trigger.ex
+++ b/lib/carbonite/trigger.ex
@@ -23,7 +23,7 @@ defmodule Carbonite.Trigger do
           excluded_columns: [String.t()],
           filtered_columns: [String.t()],
           mode: mode(),
-          override_transaction_id: nil | non_neg_integer(),
+          override_xact_id: nil | non_neg_integer(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -35,7 +35,7 @@ defmodule Carbonite.Trigger do
     field(:excluded_columns, {:array, :string}, default: [])
     field(:filtered_columns, {:array, :string}, default: [])
     field(:mode, Ecto.Enum, values: [:capture, :ignore])
-    field(:override_transaction_id, :integer)
+    field(:override_xact_id, :integer)
 
     timestamps()
   end

--- a/priv/test_repo/migrations/20210704201627_install_carbonite.exs
+++ b/priv/test_repo/migrations/20210704201627_install_carbonite.exs
@@ -7,6 +7,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
     Carbonite.Migrations.up(1)
     Carbonite.Migrations.up(2)
     Carbonite.Migrations.up(3)
+    Carbonite.Migrations.up(4)
     Carbonite.Migrations.create_trigger(:rabbits)
     Carbonite.Migrations.put_trigger_config(:rabbits, :excluded_columns, ["age"])
     Carbonite.Migrations.create_outbox("rabbits")
@@ -14,6 +15,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
 
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits)
+    Carbonite.Migrations.down(4)
     Carbonite.Migrations.down(3)
     Carbonite.Migrations.down(2)
     Carbonite.Migrations.down(1)


### PR DESCRIPTION
Fixes #45

This patch replaces the current `id` column on `transactions` with an ordinary autoincrementing integer PK, filled from a sequence. Next to it a new `xact_id` column continues to store the transaction id (from `pg_current_xact_id`). Both values used together ensure that 1) the `id` is monotonically increasing and survives a backup restore, and 2) the `changes` records can still only be inserted within the same transaction.

## TODOs

- ~~[ ] Introduce a function to generate the next/current `id` value based on the sequence + `pg_current_xact_id`~~
- [x] Re-create the `set_transaction_id` trigger with this new function
- [x] Re-create the `capture_changes` with this new function
- [x] Fix `Query.current_transaction/1`
- [x] Lots of documentation updates
