### PR TITLE
Add default prefixes to all schemas

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test,priv}/**/*.{ex,exs}"]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed 
 
-* Added `@schema_prefix "carbonite_default"` on all schemas. This will enable the usage of `Repo.insert` etc on transactions without specifying a prefix, when using the default carbonite prefix.
+* Added `@schema_prefix "carbonite_default"` on all schemas. This will enable the manual usage of `Repo.insert/2` & friends on transactions without specifying a prefix, when using the default carbonite prefix.
 
 ## [0.5.0] - 2022-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Optional tracking of previous data in changes. Set the `store_changed_from` trigger option.
 
+### Changed 
+
+* Added `@schema_prefix "carbonite_default"` on all schemas. This will enable the usage of `Repo.insert` etc on transactions without specifying a prefix, when using the default carbonite prefix.
+
 ## [0.5.0] - 2022-02-25
 
 **New migration patches:** 4

--- a/lib/carbonite.ex
+++ b/lib/carbonite.ex
@@ -14,8 +14,8 @@ defmodule Carbonite do
   @moduledoc since: "0.1.0"
 
   import Ecto.Query
-  alias Carbonite.{Outbox, Prefix, Query, Transaction, Trigger}
-  require Prefix
+  alias Carbonite.{Outbox, Schema, Query, Transaction, Trigger}
+  require Schema
 
   @type prefix :: binary()
   @type repo :: Ecto.Repo.t()
@@ -25,7 +25,7 @@ defmodule Carbonite do
   @doc "Returns the default audit trail prefix."
   @doc since: "0.1.0"
   @spec default_prefix() :: prefix()
-  def default_prefix, do: Prefix.default_prefix()
+  def default_prefix, do: Schema.default_prefix()
 
   @doc """
   Inserts a `t:Carbonite.Transaction.t/0` into the database.

--- a/lib/carbonite.ex
+++ b/lib/carbonite.ex
@@ -14,7 +14,7 @@ defmodule Carbonite do
   @moduledoc since: "0.1.0"
 
   import Ecto.Query
-  alias Carbonite.{Outbox, Schema, Query, Transaction, Trigger}
+  alias Carbonite.{Outbox, Query, Schema, Transaction, Trigger}
   require Schema
 
   @type prefix :: binary()

--- a/lib/carbonite.ex
+++ b/lib/carbonite.ex
@@ -14,7 +14,8 @@ defmodule Carbonite do
   @moduledoc since: "0.1.0"
 
   import Ecto.Query
-  alias Carbonite.{Outbox, Query, Transaction, Trigger}
+  alias Carbonite.{Outbox, Prefix, Query, Transaction, Trigger}
+  require Prefix
 
   @type prefix :: binary()
   @type repo :: Ecto.Repo.t()
@@ -24,7 +25,7 @@ defmodule Carbonite do
   @doc "Returns the default audit trail prefix."
   @doc since: "0.1.0"
   @spec default_prefix() :: prefix()
-  def default_prefix, do: "carbonite_default"
+  def default_prefix, do: Prefix.default_prefix()
 
   @doc """
   Inserts a `t:Carbonite.Transaction.t/0` into the database.

--- a/lib/carbonite/change.ex
+++ b/lib/carbonite/change.ex
@@ -18,6 +18,7 @@ defmodule Carbonite.Change do
   @moduledoc since: "0.1.0"
 
   use Ecto.Schema
+  use Carbonite.Prefix
 
   if Code.ensure_loaded?(Jason.Encoder) do
     @derive {Jason.Encoder,

--- a/lib/carbonite/change.ex
+++ b/lib/carbonite/change.ex
@@ -17,8 +17,7 @@ defmodule Carbonite.Change do
 
   @moduledoc since: "0.1.0"
 
-  use Ecto.Schema
-  use Carbonite.Prefix
+  use Carbonite.Schema
 
   if Code.ensure_loaded?(Jason.Encoder) do
     @derive {Jason.Encoder,
@@ -35,7 +34,6 @@ defmodule Carbonite.Change do
   end
 
   @primary_key false
-  @timestamps_opts [type: :utc_datetime_usec]
 
   @type id :: non_neg_integer()
 

--- a/lib/carbonite/outbox.ex
+++ b/lib/carbonite/outbox.ex
@@ -11,6 +11,7 @@ defmodule Carbonite.Outbox do
   @moduledoc since: "0.4.0"
 
   use Ecto.Schema
+  use Carbonite.Prefix
   import Ecto.Changeset
 
   @primary_key false

--- a/lib/carbonite/outbox.ex
+++ b/lib/carbonite/outbox.ex
@@ -10,7 +10,6 @@ defmodule Carbonite.Outbox do
 
   @moduledoc since: "0.4.0"
 
-  use Ecto.Schema
   use Carbonite.Schema
   import Ecto.Changeset
 

--- a/lib/carbonite/outbox.ex
+++ b/lib/carbonite/outbox.ex
@@ -11,11 +11,10 @@ defmodule Carbonite.Outbox do
   @moduledoc since: "0.4.0"
 
   use Ecto.Schema
-  use Carbonite.Prefix
+  use Carbonite.Schema
   import Ecto.Changeset
 
   @primary_key false
-  @timestamps_opts [type: :utc_datetime_usec]
 
   @type name() :: String.t()
   @type memo() :: map()

--- a/lib/carbonite/prefix.ex
+++ b/lib/carbonite/prefix.ex
@@ -1,0 +1,12 @@
+defmodule Carbonite.Prefix do
+  @moduledoc false
+
+  @doc false
+  defmacro default_prefix, do: "carbonite_default"
+
+  defmacro __using__(_opts) do
+    quote do
+      @schema_prefix "carbonite_default"
+    end
+  end
+end

--- a/lib/carbonite/schema.ex
+++ b/lib/carbonite/schema.ex
@@ -1,12 +1,14 @@
-defmodule Carbonite.Prefix do
+defmodule Carbonite.Schema do
   @moduledoc false
 
-  @doc false
   defmacro default_prefix, do: "carbonite_default"
 
   defmacro __using__(_opts) do
     quote do
+      use Ecto.Schema
       @schema_prefix "carbonite_default"
+
+      @timestamps_opts [type: :utc_datetime_usec]
     end
   end
 end

--- a/lib/carbonite/transaction.ex
+++ b/lib/carbonite/transaction.ex
@@ -10,6 +10,7 @@ defmodule Carbonite.Transaction do
   @moduledoc since: "0.1.0"
 
   use Ecto.Schema
+  use Carbonite.Prefix
   import Ecto.Changeset
 
   if Code.ensure_loaded?(Jason.Encoder) do

--- a/lib/carbonite/transaction.ex
+++ b/lib/carbonite/transaction.ex
@@ -10,7 +10,7 @@ defmodule Carbonite.Transaction do
   @moduledoc since: "0.1.0"
 
   use Ecto.Schema
-  use Carbonite.Prefix
+  use Carbonite.Schema
   import Ecto.Changeset
 
   if Code.ensure_loaded?(Jason.Encoder) do
@@ -18,7 +18,6 @@ defmodule Carbonite.Transaction do
   end
 
   @primary_key false
-  @timestamps_opts [type: :utc_datetime_usec]
 
   @type meta :: map()
 

--- a/lib/carbonite/transaction.ex
+++ b/lib/carbonite/transaction.ex
@@ -9,7 +9,6 @@ defmodule Carbonite.Transaction do
 
   @moduledoc since: "0.1.0"
 
-  use Ecto.Schema
   use Carbonite.Schema
   import Ecto.Changeset
 

--- a/lib/carbonite/trigger.ex
+++ b/lib/carbonite/trigger.ex
@@ -8,10 +8,9 @@ defmodule Carbonite.Trigger do
   @moduledoc since: "0.1.0"
 
   use Ecto.Schema
-  use Carbonite.Prefix
+  use Carbonite.Schema
 
   @primary_key {:id, :id, autogenerate: true}
-  @timestamps_opts [type: :utc_datetime_usec]
 
   @type id :: non_neg_integer()
   @type mode :: :capture | :ignore

--- a/lib/carbonite/trigger.ex
+++ b/lib/carbonite/trigger.ex
@@ -7,7 +7,6 @@ defmodule Carbonite.Trigger do
 
   @moduledoc since: "0.1.0"
 
-  use Ecto.Schema
   use Carbonite.Schema
 
   @primary_key {:id, :id, autogenerate: true}

--- a/lib/carbonite/trigger.ex
+++ b/lib/carbonite/trigger.ex
@@ -8,6 +8,7 @@ defmodule Carbonite.Trigger do
   @moduledoc since: "0.1.0"
 
   use Ecto.Schema
+  use Carbonite.Prefix
 
   @primary_key {:id, :id, autogenerate: true}
   @timestamps_opts [type: :utc_datetime_usec]

--- a/priv/test_repo/migrations/20210704201537_create_rabbits.exs
+++ b/priv/test_repo/migrations/20210704201537_create_rabbits.exs
@@ -5,8 +5,8 @@ defmodule Carbonite.TestRepo.Migrations.CreateRabbits do
 
   def change do
     create table(:rabbits) do
-      add :name, :string
-      add :age, :integer
+      add(:name, :string)
+      add(:age, :integer)
     end
   end
 end

--- a/priv/test_repo/migrations/20221011201645_install_carbonite_foo.exs
+++ b/priv/test_repo/migrations/20221011201645_install_carbonite_foo.exs
@@ -9,7 +9,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
     Carbonite.Migrations.up(3, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.up(4, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.up(5, carbonite_prefix: "alternate_test_schema")
-     end
+  end
 
   def down do
     Carbonite.Migrations.down(5, carbonite_prefix: "alternate_test_schema")

--- a/priv/test_repo/migrations/20221011201645_install_carbonite_foo.exs
+++ b/priv/test_repo/migrations/20221011201645_install_carbonite_foo.exs
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
+  use Ecto.Migration
+
+  def up do
+    Carbonite.Migrations.up(1, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(2, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(3, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(4, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(5, carbonite_prefix: "alternate_test_schema")
+     end
+
+  def down do
+    Carbonite.Migrations.down(5, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.down(4, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.down(3, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.down(2, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.down(1, carbonite_prefix: "alternate_test_schema")
+  end
+end

--- a/test/carbonite/change_test.exs
+++ b/test/carbonite/change_test.exs
@@ -8,7 +8,7 @@ defmodule Carbonite.ChangeTest do
   describe "Schema" do
     test "uses the default carbonite_prefix" do
       {sql, _} = SQL.to_sql(:all, TestRepo, Change)
-      assert String.contains?(sql, "\"carbonite_default\".\"changes\"")
+      assert String.contains?(sql, ~s("carbonite_default"."changes"))
     end
   end
 

--- a/test/carbonite/change_test.exs
+++ b/test/carbonite/change_test.exs
@@ -2,6 +2,15 @@
 
 defmodule Carbonite.ChangeTest do
   use Carbonite.APICase, async: true
+  alias Carbonite.{Change, TestRepo}
+  alias Ecto.Adapters.SQL
+
+  describe "Schema" do
+    test "uses the default carbonite_prefix" do
+      {sql, _} = SQL.to_sql(:all, TestRepo, Change)
+      assert String.contains?(sql, "\"carbonite_default\".\"changes\"")
+    end
+  end
 
   describe "Jason.Encoder implementation" do
     test "Carbonite.Change can be encoded to JSON" do

--- a/test/carbonite/outbox_test.exs
+++ b/test/carbonite/outbox_test.exs
@@ -3,7 +3,8 @@
 defmodule Carbonite.OutboxTest do
   use Carbonite.APICase, async: true
   import Carbonite.Outbox
-  alias Carbonite.Outbox
+  alias Carbonite.{Outbox, TestRepo}
+  alias Ecto.Adapters.SQL
 
   describe "changeset/2" do
     test "casts attributes" do
@@ -17,6 +18,13 @@ defmodule Carbonite.OutboxTest do
       cs = changeset(%Outbox{}, %{last_transaction_id: 500_000, memo: nil})
       refute cs.valid?
       assert [{:memo, {_msg, [validation: :required]}}] = cs.errors
+    end
+  end
+
+  describe "Schema" do
+    test "uses the default carbonite_prefix" do
+      {sql, _} = SQL.to_sql(:all, TestRepo, Outbox)
+      assert String.contains?(sql, "\"carbonite_default\".\"outboxes\"")
     end
   end
 end

--- a/test/carbonite/outbox_test.exs
+++ b/test/carbonite/outbox_test.exs
@@ -24,7 +24,7 @@ defmodule Carbonite.OutboxTest do
   describe "Schema" do
     test "uses the default carbonite_prefix" do
       {sql, _} = SQL.to_sql(:all, TestRepo, Outbox)
-      assert String.contains?(sql, "\"carbonite_default\".\"outboxes\"")
+      assert String.contains?(sql, ~s("carbonite_default"."outboxes"))
     end
   end
 end

--- a/test/carbonite/transaction_test.exs
+++ b/test/carbonite/transaction_test.exs
@@ -9,7 +9,7 @@ defmodule Carbonite.TransactionTest do
   describe "Schema" do
     test "uses the default carbonite_prefix" do
       {sql, _} = SQL.to_sql(:all, TestRepo, Transaction)
-      assert String.contains?(sql, "\"carbonite_default\".\"transactions\"")
+      assert String.contains?(sql, ~s("carbonite_default"."transactions"))
     end
   end
 

--- a/test/carbonite/transaction_test.exs
+++ b/test/carbonite/transaction_test.exs
@@ -2,7 +2,16 @@
 
 defmodule Carbonite.TransactionTest do
   use Carbonite.APICase, async: true
-  import Carbonite.Transaction
+  alias Carbonite.{TestRepo, Transaction}
+  alias Ecto.Adapters.SQL
+  import Transaction
+
+  describe "Schema" do
+    test "uses the default carbonite_prefix" do
+      {sql, _} = SQL.to_sql(:all, TestRepo, Transaction)
+      assert String.contains?(sql, "\"carbonite_default\".\"transactions\"")
+    end
+  end
 
   describe "changeset/1" do
     test "transaction_changesets an Ecto.Changeset for a transaction" do

--- a/test/carbonite/trigger_test.exs
+++ b/test/carbonite/trigger_test.exs
@@ -1,0 +1,12 @@
+defmodule Carbonite.TriggerTest do
+  use Carbonite.APICase, async: true
+  alias Carbonite.{TestRepo, Trigger}
+  alias Ecto.Adapters.SQL
+
+  describe "Schema" do
+    test "uses the default carbonite_prefix" do
+      {sql, _} = SQL.to_sql(:all, TestRepo, Trigger)
+      assert String.contains?(sql, "\"carbonite_default\".\"triggers\"")
+    end
+  end
+end

--- a/test/carbonite/trigger_test.exs
+++ b/test/carbonite/trigger_test.exs
@@ -6,7 +6,7 @@ defmodule Carbonite.TriggerTest do
   describe "Schema" do
     test "uses the default carbonite_prefix" do
       {sql, _} = SQL.to_sql(:all, TestRepo, Trigger)
-      assert String.contains?(sql, "\"carbonite_default\".\"triggers\"")
+      assert String.contains?(sql, ~s("carbonite_default"."triggers"))
     end
   end
 end

--- a/test/carbonite_test.exs
+++ b/test/carbonite_test.exs
@@ -4,6 +4,7 @@ defmodule CarboniteTest do
   use Carbonite.APICase, async: true
   import Carbonite
   alias Carbonite.{Outbox, Rabbit, TestRepo, Transaction}
+  alias Ecto.Adapters.SQL
 
   defp insert_jack do
     %{name: "Jack", age: 99}
@@ -46,6 +47,14 @@ defmodule CarboniteTest do
 
       assert tx1.meta == %{"foo" => 1}
       assert tx2.meta == %{"foo" => 1}
+    end
+
+    test "carbonite_prefix option works as expected" do
+      assert {:ok, _tx} =
+               insert_transaction(TestRepo, %{}, carbonite_prefix: "alternate_test_schema")
+
+      assert %{num_rows: 1} =
+               SQL.query!(TestRepo, "SELECT * FROM alternate_test_schema.transactions")
     end
   end
 


### PR DESCRIPTION
The example can probably not work like outlined #53. Since `changeset/1` does not accept the prefix, right?