### PR TITLE
Fix flaky test in MigrationsTest

### DIFF
--- a/test/carbonite/migrations_test.exs
+++ b/test/carbonite/migrations_test.exs
@@ -3,6 +3,7 @@
 defmodule Carbonite.MigrationsTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
+  import Ecto.Query, only: [order_by: 2]
 
   defmodule UnboxedTestRepo do
     use Ecto.Repo,
@@ -59,7 +60,9 @@ defmodule Carbonite.MigrationsTest do
   end
 
   defp select_all_transactions do
-    UnboxedTestRepo.all(Carbonite.Query.transactions(preload: true))
+    Carbonite.Query.transactions(preload: true)
+    |> order_by({:asc, :inserted_at})
+    |> UnboxedTestRepo.all()
   end
 
   defp delete_all_transactions do

--- a/test/support/api_case.ex
+++ b/test/support/api_case.ex
@@ -64,5 +64,5 @@ defmodule Carbonite.APICase do
     |> TestRepo.all()
   end
 
-  def ids(set), do: Enum.map(set, & &1.id)
+  def ids(set), do: set |> Enum.map(& &1.id) |> Enum.sort()
 end


### PR DESCRIPTION
Came across two flaky tests just now.

## Flaky 1: select_all_transactions was unordered

```
  2) test insert_migration_transaction_after_begin/1 makes the migration automatically insert a transaction (Carbonite.MigrationsTest)
     test/carbonite/migrations_test.exs:70
     match (=) failed
     code:  assert [_, %{meta: %{"direction" => "down"}}] = select_all_transactions()
     left:  [_, %{meta: %{"direction" => "down"}}]
     right: [
              %Carbonite.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, "carbonite_default", "transactions">, changes: [%Carbonite.Change{__meta__: #Ecto.Schema.Metadat
a<:loaded, "carbonite_default", "changes">, changed: [], changed_from: nil, data: %{"id" => 588, "name" => "Migrato"}, id: 672, op: :delete, table_name: "rabbits", table_pk:
["588"], table_prefix: "public", transaction: #Ecto.Association.NotLoaded<association :transaction is not loaded>, transaction_id: 760076, transaction_xact_id: 1009545}], id:
 760076, inserted_at: ~U[2022-10-11 09:14:32.515415Z], meta: %{"direction" => "down", "name" => "carbonite/migrations_test/insert_migrato", "type" => "migration"}, xact_id: 1
009545},
              %Carbonite.Transaction{
                meta: %{"direction" => "up", "name" => "carbonite/migrations_test/insert_migrato", "type" => "migration"},
                __meta__: #Ecto.Schema.Metadata<:loaded, "carbonite_default", "transactions">,
                changes: [%Carbonite.Change{__meta__: #Ecto.Schema.Metadata<:loaded, "carbonite_default", "changes">, changed: [], changed_from: nil, data: %{"id" => 588, "na
me" => "Migrato"}, id: 671, op: :insert, table_name: "rabbits", table_pk: ["588"], table_prefix: "public", transaction: #Ecto.Association.NotLoaded<association :transaction i
s not loaded>, transaction_id: 760075, transaction_xact_id: 1009543}],
                id: 760075,
                inserted_at: ~U[2022-10-11 09:14:32.504610Z],
                xact_id: 1009543
              }
            ]
     stacktrace:
       test/carbonite/migrations_test.exs:86: anonymous fn/0 in Carbonite.MigrationsTest....
```

## Flaky 2: ids 

```
  2) test outbox_done/1 filters by id >= MIN(outboxes.last_transaction_id) (Carbonite.QueryTest)
     test/carbonite/query_test.exs:135
     Assertion with == failed
     code:  assert ids(outbox_done()) == [100_000, 200_000]
     left:  [200000, 100000]
     right: [100000, 200000]
     stacktrace:
       test/carbonite/query_test.exs:140: (test)
```