### PR TITLE
Make change trigger deferrable and optionally immediately deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Added
+
+* Added `:initially` option to `create_trigger/2` to create triggers with `IMMEDIATE DEFERRED` constraint option. This allows to conditionally insert the `Carbonite.Transaction` record at the end of the transaction. In order to use this for already existing triggers, you need to drop them (`drop_trigger/2`) and re-create them.
+
+### Changed
+
+* Made the changes trigger `DEFERRABLE`. As part of the `:initially` option of `create_trigger/2`, we chose to make triggers `DEFERRABLE` by default. Again, for any existing triggers, this won't take effect, but newly created triggers will use this constraint option.
+
 ## [0.6.0] - 2022-10-12
 
 **New migration patches:** 5

--- a/README.md
+++ b/README.md
@@ -284,6 +284,43 @@ def change do
 end
 ```
 
+### "Empty" transactions when no changes have been recorded
+
+By default, Carbonite will store the `Carbonite.Transaction` record regardless of whether in the corresponding database transaction any changes were recorded or not. In fact, there is nothing special about the behaviour of the following code:
+
+```elixir
+Ecto.Multi.new()
+|> Carbonite.Multi.insert_transaction(%{meta: %{type: "rabbit_inserted"}})
+|> Ecto.Multi.run(:rabbit, &maybe_insert_rabbit/2)
+|> MyApp.Repo.transaction()
+```
+
+Depending on the behaviour of `maybe_insert_rabbit/2`, the transaction may result in one of these outcomes:
+
+1. The transaction succeeds and the rabbit is inserted. A `Carbonite.Transaction` is recorded alongside a `Carbonite.Change`.
+2. The transaction succeeds but *no rabbit is inserted*. The `Carbonite.Transaction` is recorded but will be empty, that is, not associated to any `Carbonite.Change` records.
+3. The transaction fails and is rolled back. The `Carbonite.Transaction` is not persisted.
+
+Outcome (1) and (3) above are engrained in Carbonite's trigger logic and can not be changed.
+
+The second outcome can be considered "intended behaviour" and there are good reasons for keeping the `Carbonite.Transaction` around. However, if your use-case indicates that you should not store `Carbonite.Transactions` when nothing was changed, you need to:
+
+1. Set the trigger to `INITIALLY DEFERRED` when it is created.
+2. Re-order your application logic ...
+3. ... and only insert the transaction when needed.
+
+```elixir
+# In the migration where the trigger is created
+Carbonite.Migrations.create_trigger(:rabbits, initially: "deferred")
+```
+
+```elixir
+Ecto.Multi.new()
+|> Ecto.Multi.run(:rabbit, &maybe_insert_rabbit/2)
+|> Ecto.Multi.run(:carbonite_transaction, &maybe_insert_carbonite_transaction/2)
+|> MyApp.Repo.transaction()
+```
+
 ## Retrieving data
 
 Of course, persisting the audit trail is not an end in itself. At some point you will want to read the data back and make it accessible to the user. `Carbonite.Query` offers a small suite of helper functions that make it easier to query the database for `Transaction` and `Change` records.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Ecto.Multi.new()
 |> MyApp.Repo.transaction()
 ```
 
+See `Carbonite.Migrations.create_trigger/2` for further information.
+
 ## Retrieving data
 
 Of course, persisting the audit trail is not an end in itself. At some point you will want to read the data back and make it accessible to the user. `Carbonite.Query` offers a small suite of helper functions that make it easier to query the database for `Transaction` and `Change` records.

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -91,6 +91,17 @@ defmodule Carbonite.Migrations do
   * `table_prefix` is the name of the schema the table lives in
   * `carbonite_prefix` is the schema of the audit trail, defaults to `"carbonite_default"`
   * `initially` can be either of `:immediate` or `:deferred`, defaults to `:immediate`
+
+  ## Deferred triggers
+
+  You may create the trigger with `initially: :deferred` option to make it run at the end of your
+  database transactions. In combination with application logic that only conditionally inserts
+  the `Carbonite.Transaction`, this can be used to avoid storing "empty" transactions, i.e.
+  `Carbonite.Transaction` records without associated `Carbonite.Change`.
+
+  Please be aware that this is not recommended by the Carbonite team. Instead we recommend to
+  retain the empty transactions and optionally remove them in a preprocessing step or your
+  outbox mechanism. Make sure you know how deferred triggers work before using this option.
   """
   @doc since: "0.4.0"
   @spec create_trigger(table_name()) :: :ok

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -81,6 +81,7 @@ defmodule Carbonite.Migrations do
   @default_table_prefix "public"
 
   @type trigger_option :: {:table_prefix, prefix()} | {:carbonite_prefix, prefix()}
+  @type create_trigger_option :: trigger_option() | {:initially, :deferred | :immediate}
 
   @doc """
   Installs a change capture trigger on a table.
@@ -89,18 +90,23 @@ defmodule Carbonite.Migrations do
 
   * `table_prefix` is the name of the schema the table lives in
   * `carbonite_prefix` is the schema of the audit trail, defaults to `"carbonite_default"`
+  * `initially` can be either of `:immediate` or `:deferred`, defaults to `:immediate`
   """
   @doc since: "0.4.0"
   @spec create_trigger(table_name()) :: :ok
-  @spec create_trigger(table_name(), [trigger_option()]) :: :ok
+  @spec create_trigger(table_name(), [create_trigger_option()]) :: :ok
   def create_trigger(table_name, opts \\ []) do
     table_prefix = Keyword.get(opts, :table_prefix, @default_table_prefix)
     carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+    initially = Keyword.get(opts, :initially, :immediate)
+
+    validate_initially_option!(initially)
 
     """
-    CREATE TRIGGER capture_changes_into_#{carbonite_prefix}_trigger
+    CREATE CONSTRAINT TRIGGER capture_changes_into_#{carbonite_prefix}_trigger
     AFTER INSERT OR UPDATE OR DELETE
     ON #{table_prefix}.#{table_name}
+    DEFERRABLE INITIALLY #{initially}
     FOR EACH ROW
     EXECUTE PROCEDURE #{carbonite_prefix}.capture_changes();
     """
@@ -124,6 +130,12 @@ defmodule Carbonite.Migrations do
     |> squish_and_execute()
 
     :ok
+  end
+
+  defp validate_initially_option!(initially) when initially in [:immediate, :deferred], do: :ok
+
+  defp validate_initially_option!(initially) do
+    raise("initially must be one of [:immediate, :deferred], but is #{inspect(initially)}")
   end
 
   @doc """

--- a/lib/carbonite/migrations/v5.ex
+++ b/lib/carbonite/migrations/v5.ex
@@ -139,7 +139,7 @@ defmodule Carbonite.Migrations.V5 do
   def up(opts) do
     prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
 
-    lock_changes(prefix)
+    lock_table(prefix, "changes")
 
     # ------------- `changed_from` ---------------
 
@@ -165,7 +165,7 @@ defmodule Carbonite.Migrations.V5 do
   def down(opts) do
     prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
 
-    lock_changes(prefix)
+    lock_table(prefix, "changes")
 
     # ------------- `changed_from` ------------
 
@@ -182,9 +182,5 @@ defmodule Carbonite.Migrations.V5 do
     V4.create_capture_changes_procedure(prefix)
 
     :ok
-  end
-
-  defp lock_changes(prefix) do
-    squish_and_execute("LOCK TABLE #{prefix}.changes IN EXCLUSIVE MODE;")
   end
 end

--- a/test/support/test_repo/migrations/20221102120000_create_deferred_rabbits.exs
+++ b/test/support/test_repo/migrations/20221102120000_create_deferred_rabbits.exs
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.TestRepo.Migrations.CreateDeferredRabbits do
+  use Ecto.Migration
+
+  def change do
+    create table(:deferred_rabbits) do
+      add(:name, :string)
+      add(:age, :integer)
+    end
+
+    Carbonite.Migrations.create_trigger(:deferred_rabbits, initially: :deferred)
+  end
+
+  def down do
+    Carbonite.Migrations.drop_trigger(:deferred_rabbits)
+
+    drop(table(:deferred_rabbits))
+  end
+end


### PR DESCRIPTION
This patch makes the change trigger `DEFERRABLE` by changing the behaviour of `Carbonite.Migrations.create_trigger/2`. Existing triggers will not be changed.

A new `:initially` option can be used to set the constraint to `INITIALLY DEFERRED` and hence make it evaluate at the end of a DB transaction. This allows to insert the `Carbonite.Transaction` only conditionally *at the end of the transaction*.

Relates to [[#60]](https://github.com/bitcrowd/carbonite/issues/60)