### PR TITLE
fix(docs): correctly use `table_prefix` option in migration comments

### DIFF
--- a/lib/mix/tasks/carbonite.gen.initial_migration.ex
+++ b/lib/mix/tasks/carbonite.gen.initial_migration.ex
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Carbonite.Gen.InitialMigration do
       # Install a trigger for a table:
       #
       #    Carbonite.Migrations.create_trigger("rabbits")
-      #    Carbonite.Migrations.create_trigger("rabbits", prefix: "animals")
+      #    Carbonite.Migrations.create_trigger("rabbits", table_prefix: "animals")
       #    Carbonite.Migrations.create_trigger("rabbits", carbonite_prefix: "carbonite_other")
 
       # Configure trigger options:
@@ -75,7 +75,7 @@ defmodule Mix.Tasks.Carbonite.Gen.InitialMigration do
       # Remove trigger from a table:
       #
       #    Carbonite.Migrations.drop_trigger("rabbits")
-      #    Carbonite.Migrations.drop_trigger("rabbits", prefix: "animals")
+      #    Carbonite.Migrations.drop_trigger("rabbits", table_prefix: "animals")
       #    Carbonite.Migrations.drop_trigger("rabbits", carbonite_prefix: "carbonite_other")
 
       # Make sure to apply the same carbonite_prefix option here.


### PR DESCRIPTION
Fixes the comments in the initial migration incorrectly using `prefix` instead of the correct [`table_prefix`](https://github.com/cschmatzler/carbonite/blob/3e9e2c3f054a54ab1eaf5cb3ac00245ff57819e4/lib/carbonite/migrations.ex#L91).