### PR TITLE
Add :to option to Carbonite.override_mode/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+* Add `:to` option to `Carbonite.override_mode/2` to specify an explicit target mode. Useful for toggling the mode around test fixtures.
+
 ## [0.7.2] - 2023-03-07
 
 ### Fixed

--- a/lib/carbonite/multi.ex
+++ b/lib/carbonite/multi.ex
@@ -7,6 +7,7 @@ defmodule Carbonite.Multi do
 
   @moduledoc since: "0.2.0"
 
+  alias Carbonite.Trigger
   alias Ecto.Multi
 
   @type prefix :: binary()
@@ -69,7 +70,7 @@ defmodule Carbonite.Multi do
   """
   @doc since: "0.2.0"
   @spec override_mode(Multi.t()) :: Multi.t()
-  @spec override_mode(Multi.t(), [prefix_option()]) :: Multi.t()
+  @spec override_mode(Multi.t(), [{:to, Trigger.mode()} | prefix_option()]) :: Multi.t()
   def override_mode(%Multi{} = multi, opts \\ []) do
     Multi.run(multi, :carbonite_triggers, fn repo, _state ->
       {:ok, Carbonite.override_mode(repo, opts)}

--- a/test/carbonite_test.exs
+++ b/test/carbonite_test.exs
@@ -103,6 +103,18 @@ defmodule CarboniteTest do
         insert_jack()
       end
     end
+
+    test "can toggle override mode with the :to option" do
+      assert override_mode(TestRepo, to: :ignore) == :ok
+
+      insert_jack()
+
+      assert override_mode(TestRepo, to: :capture) == :ok
+
+      assert_raise Postgrex.Error, fn ->
+        insert_jack()
+      end
+    end
   end
 
   describe "process/4" do


### PR DESCRIPTION
This PR adds the `:to` option to `Carbonite.override_mode/2` which allows to directly set a target mode on the trigger configuration (of all tables, as before). This is useful when one wants to temporarily set the mode to `:ignore` (e.g. during test setup).

Also improved the documentation on testing / bypassing Carbonite a bit.

Relates to #79