### PR TITLE
[#82] Array changes are not always detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+**New migration patches:** 6
+
+### Fixed
+
+* Correctly detect changes to array fields.
+
+Previously, detection of changes was done via the `@>` operator to test "containment" of a `{col: old_value}` JSON object in the JSON object of the new record. Unfortunately, Postgres' "jsonb containment" (see [docs](https://www.postgresql.org/docs/15/datatype-json.html#JSON-CONTAINMENT)) views array subsets as contained within their subsets, as well as arrays in different orders to be contained within each other. Both of these cases we want to track as a changed value.
+
+⚠️ This bug caused Carbonite to not identify a changed array field correctly, meaning it may not have been listed in the `changed` and `changed_from` columns of the `Carbonite.Change` record. Unfortunately, this also means that **versions may have been discarded entirely** if no other fields of a record were updated at the same time.
+
 ## [0.8.0] - 2023-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ defmodule MyApp.Repo.Migrations.InstallCarbonite do
     Carbonite.Migrations.up(3)
     Carbonite.Migrations.up(4)
     Carbonite.Migrations.up(5)
+    Carbonite.Migrations.up(6)
 
     # For each table that you want to capture changes of, you need to install the trigger.
     Carbonite.Migrations.create_trigger(:rabbits)
@@ -144,6 +145,7 @@ defmodule MyApp.Repo.Migrations.InstallCarbonite do
     Carbonite.Migrations.drop_trigger(:rabbits)
 
     # Drop the Carbonite tables.
+    Carbonite.Migrations.down(6)
     Carbonite.Migrations.down(5)
     Carbonite.Migrations.down(4)
     Carbonite.Migrations.down(3)

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations do
   # --------------------------------- patch levels ---------------------------------
 
   @initial_patch 1
-  @current_patch 5
+  @current_patch 6
 
   @doc false
   @spec initial_patch :: non_neg_integer()

--- a/lib/carbonite/migrations/v6.ex
+++ b/lib/carbonite/migrations/v6.ex
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.Migrations.V6 do
+  @moduledoc false
+
+  use Ecto.Migration
+  use Carbonite.Migrations.Version
+  alias Carbonite.Migrations.V5
+
+  @type prefix :: binary()
+
+  @type up_option :: {:carbonite_prefix, prefix()}
+
+  @spec create_capture_changes_procedure(prefix()) :: :ok
+  def create_capture_changes_procedure(prefix) do
+    """
+    CREATE OR REPLACE FUNCTION #{prefix}.capture_changes() RETURNS TRIGGER AS
+    $body$
+    DECLARE
+      trigger_row #{prefix}.triggers;
+      change_row #{prefix}.changes;
+      pk_source RECORD;
+      col_name VARCHAR;
+      pk_col_val VARCHAR;
+      old_value JSONB;
+    BEGIN
+      /* load trigger config */
+      SELECT *
+        INTO trigger_row
+        FROM #{prefix}.triggers
+        WHERE table_prefix = TG_TABLE_SCHEMA AND table_name = TG_TABLE_NAME;
+
+      IF
+        (trigger_row.mode = 'ignore' AND (trigger_row.override_xact_id IS NULL OR trigger_row.override_xact_id != pg_current_xact_id())) OR
+        (trigger_row.mode = 'capture' AND trigger_row.override_xact_id = pg_current_xact_id())
+      THEN
+        RETURN NULL;
+      END IF;
+
+      /* instantiate change row */
+      change_row = ROW(
+        NEXTVAL('#{prefix}.changes_id_seq'),
+        pg_current_xact_id(),
+        LOWER(TG_OP::TEXT),
+        TG_TABLE_SCHEMA::TEXT,
+        TG_TABLE_NAME::TEXT,
+        NULL,
+        NULL,
+        '{}',
+        NULL,
+        NULL
+      );
+
+      /* build table_pk */
+      IF trigger_row.primary_key_columns != '{}' THEN
+        IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+          pk_source := NEW;
+        ELSIF (TG_OP = 'DELETE') THEN
+          pk_source := OLD;
+        END IF;
+
+        change_row.table_pk := '{}';
+
+        FOREACH col_name IN ARRAY trigger_row.primary_key_columns LOOP
+          EXECUTE 'SELECT $1.' || col_name || '::TEXT' USING pk_source INTO pk_col_val;
+          change_row.table_pk := change_row.table_pk || pk_col_val;
+        END LOOP;
+      END IF;
+
+      /* fill in changed data */
+      IF (TG_OP = 'UPDATE') THEN
+        change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
+        change_row.changed_from = '{}'::JSONB;
+
+        FOR col_name, old_value
+        IN SELECT * FROM jsonb_each(to_jsonb(OLD.*) - trigger_row.excluded_columns)
+        LOOP
+          IF (change_row.data->col_name)::JSONB != old_value THEN
+            change_row.changed_from := jsonb_set(change_row.changed_from, ARRAY[col_name], old_value);
+          END IF;
+        END LOOP;
+
+        change_row.changed := ARRAY(SELECT jsonb_object_keys(change_row.changed_from));
+
+        IF change_row.changed = '{}' THEN
+          /* All changed fields are ignored. Skip this update. */
+          RETURN NULL;
+        END IF;
+
+        /* Persisting the old data is opt-in, discard if not configured. */
+        IF trigger_row.store_changed_from IS FALSE THEN
+          change_row.changed_from := NULL;
+        END IF;
+      ELSIF (TG_OP = 'DELETE') THEN
+        change_row.data = to_jsonb(OLD.*) - trigger_row.excluded_columns;
+      ELSIF (TG_OP = 'INSERT') THEN
+        change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
+      END IF;
+
+      /* filtered columns */
+      FOREACH col_name IN ARRAY trigger_row.filtered_columns LOOP
+        change_row.data = jsonb_set(change_row.data, ('{' || col_name || '}')::TEXT[], jsonb('"[FILTERED]"'));
+      END LOOP;
+
+      /* insert, fail gracefully unless transaction record present or NEXTVAL has never been called */
+      BEGIN
+        change_row.transaction_id = CURRVAL('#{prefix}.transactions_id_seq');
+
+        /* verify that xact_id matches */
+        IF NOT
+          EXISTS(
+            SELECT 1 FROM #{prefix}.transactions
+            WHERE id = change_row.transaction_id AND xact_id = change_row.transaction_xact_id
+          )
+        THEN
+          RAISE USING ERRCODE = 'foreign_key_violation';
+        END IF;
+
+        INSERT INTO #{prefix}.changes VALUES (change_row.*);
+      EXCEPTION WHEN foreign_key_violation OR object_not_in_prerequisite_state THEN
+          RAISE '% on table %.% without prior INSERT into #{prefix}.transactions',
+            TG_OP, TG_TABLE_SCHEMA, TG_TABLE_NAME USING ERRCODE = 'foreign_key_violation';
+      END;
+
+      RETURN NULL;
+    END;
+    $body$
+    LANGUAGE plpgsql;
+    """
+    |> squish_and_execute()
+
+    :ok
+  end
+
+  @impl true
+  @spec up([up_option()]) :: :ok
+  def up(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    create_capture_changes_procedure(prefix)
+
+    :ok
+  end
+
+  @type down_option :: {:carbonite_prefix, prefix()}
+
+  @impl true
+  @spec down([down_option()]) :: :ok
+  def down(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    V5.create_capture_changes_procedure(prefix)
+
+    :ok
+  end
+end

--- a/test/support/rabbit.ex
+++ b/test/support/rabbit.ex
@@ -9,6 +9,7 @@ defmodule Carbonite.Rabbit do
   schema "rabbits" do
     field(:name, :string)
     field(:age, :integer)
+    field(:carrots, {:array, :string})
   end
 
   def create_changeset(params) do

--- a/test/support/test_repo/migrations/20210704201537_create_rabbits.exs
+++ b/test/support/test_repo/migrations/20210704201537_create_rabbits.exs
@@ -7,6 +7,7 @@ defmodule Carbonite.TestRepo.Migrations.CreateRabbits do
     create table(:rabbits) do
       add(:name, :string)
       add(:age, :integer)
+      add(:carrots, {:array, :string}, default: "{}")
     end
   end
 end

--- a/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
+++ b/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
@@ -9,6 +9,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
     Carbonite.Migrations.up(3)
     Carbonite.Migrations.up(4)
     Carbonite.Migrations.up(5)
+    Carbonite.Migrations.up(6)
     Carbonite.Migrations.create_trigger(:rabbits)
     Carbonite.Migrations.put_trigger_config(:rabbits, :excluded_columns, ["age"])
     Carbonite.Migrations.put_trigger_config(:rabbits, :store_changed_from, true)
@@ -17,6 +18,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
 
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits)
+    Carbonite.Migrations.down(6)
     Carbonite.Migrations.down(5)
     Carbonite.Migrations.down(4)
     Carbonite.Migrations.down(3)

--- a/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
+++ b/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
@@ -9,6 +9,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
     Carbonite.Migrations.up(3, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.up(4, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.up(5, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(6, carbonite_prefix: "alternate_test_schema")
 
     Carbonite.Migrations.create_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
@@ -24,6 +25,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
+    Carbonite.Migrations.down(6, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.down(5, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.down(4, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.down(3, carbonite_prefix: "alternate_test_schema")

--- a/test/support/test_repo/migrations/20221102120000_create_deferred_rabbits.exs
+++ b/test/support/test_repo/migrations/20221102120000_create_deferred_rabbits.exs
@@ -7,6 +7,7 @@ defmodule Carbonite.TestRepo.Migrations.CreateDeferredRabbits do
     create table(:deferred_rabbits) do
       add(:name, :string)
       add(:age, :integer)
+      add(:carrots, {:array, :string}, default: "{}")
     end
 
     Carbonite.Migrations.create_trigger(:deferred_rabbits, initially: :deferred)


### PR DESCRIPTION
This patch fixes a bug in the trigger that prevented changes to array fields from being detected correctly. Root cause was the use of the "jsonb containment" operator to test whether a `(key, old value)` tuple was "contained" within the JSON object of the updated record, where instead we should have properly tested the values for equality.

Fixes #82.

## Relevant changes between V5 & V6

```diff
@@ -22,8 +22,7 @@
       pk_source RECORD;
       col_name VARCHAR;
       pk_col_val VARCHAR;
-      old_field RECORD;
-      old_field_jsonb JSONB;
+      old_value JSONB;
     BEGIN
       /* load trigger config */
       SELECT *
@@ -73,12 +72,11 @@
         change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
         change_row.changed_from = '{}'::JSONB;

-        FOR old_field_jsonb
-        IN SELECT jsonb_build_object(key, value)
-        FROM jsonb_each(to_jsonb(OLD.*) - trigger_row.excluded_columns)
+        FOR col_name, old_value
+        IN SELECT * FROM jsonb_each(to_jsonb(OLD.*) - trigger_row.excluded_columns)
         LOOP
-          IF NOT change_row.data @> old_field_jsonb THEN
-            change_row.changed_from := change_row.changed_from || old_field_jsonb;
+          IF (change_row.data->col_name)::JSONB != old_value THEN
+            change_row.changed_from := jsonb_set(change_row.changed_from, ARRAY[col_name], old_value);
           END IF;
         END LOOP;
```