### PR TITLE
[#86] Fix incompatibility with PostgreSQL 16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+* Fixed a minor incompatibility with recently released Postgres 16.0.
+
 ## [0.9.0] - 2024-04-27
 
 **New migration patches:** 6

--- a/lib/carbonite/migrations/v3.ex
+++ b/lib/carbonite/migrations/v3.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations.V3 do
     create table("outboxes", primary_key: false, prefix: prefix) do
       add(:name, :string, null: false, primary_key: true)
       add(:memo, :map, null: false, default: "{}")
-      add(:last_transaction_id, :xid8, null: false, default: "0::TEXT::xid8")
+      add(:last_transaction_id, :xid8, null: false, default: "0")
 
       timestamps(type: :utc_datetime_usec)
     end


### PR DESCRIPTION
This patch fixes outdated migration V3 which set a column to default to `0::TEXT::xid8` which became invalid syntax in Postgres 16. The relevant column has since been updated to a `BIGINT` and the default is set to `0` in migration V4.

Selected fix is to replace the invalid syntax in migration V3 with `0` which seems to work fine with xid8 columns as well. Tested in Postgres 13.12 and 16.0.

Fixes #86.