### PR TITLE
Add index on changes.transaction_id to speed up purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**New migration patches:** 7
+
+### Added
+
+- Add a new index on `transaction_id` in the `changes` table, to speed up queries for a transaction's changes and the `purge` operation. The existing `changes_transaction_id_index` (on `transaction_xact_id` column) has been renamed to `changes_transaction_xact_id_index`.
+
 ## [0.10.0] - 2024-09-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ defmodule MyApp.Repo.Migrations.InstallCarbonite do
     Carbonite.Migrations.up(4)
     Carbonite.Migrations.up(5)
     Carbonite.Migrations.up(6)
+    Carbonite.Migrations.up(7)
 
     # For each table that you want to capture changes of, you need to install the trigger.
     Carbonite.Migrations.create_trigger(:rabbits)
@@ -145,6 +146,7 @@ defmodule MyApp.Repo.Migrations.InstallCarbonite do
     Carbonite.Migrations.drop_trigger(:rabbits)
 
     # Drop the Carbonite tables.
+    Carbonite.Migrations.down(7)
     Carbonite.Migrations.down(6)
     Carbonite.Migrations.down(5)
     Carbonite.Migrations.down(4)

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations do
   # --------------------------------- patch levels ---------------------------------
 
   @initial_patch 1
-  @current_patch 6
+  @current_patch 7
 
   @doc false
   @spec initial_patch :: non_neg_integer()

--- a/lib/carbonite/migrations/v7.ex
+++ b/lib/carbonite/migrations/v7.ex
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.Migrations.V7 do
+  @moduledoc false
+
+  use Ecto.Migration
+  use Carbonite.Migrations.Version
+
+  @type prefix :: binary()
+
+  @type up_option :: {:carbonite_prefix, prefix()} | {:concurrently, boolean()}
+
+  @impl true
+  @spec up([up_option()]) :: :ok
+  def up(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+    concurrently = Keyword.get(opts, :concurrently, false)
+
+    # Ecto.Migration.rename/2 does not yet support :prefix
+    # https://github.com/elixir-ecto/ecto_sql/pull/573
+
+    """
+    ALTER INDEX #{prefix}.changes_transaction_id_index
+    RENAME TO changes_transaction_xact_id_index;
+    """
+    |> squish_and_execute()
+
+    create(index(:changes, [:transaction_id], prefix: prefix, concurrently: concurrently))
+
+    :ok
+  end
+
+  @type down_option :: {:carbonite_prefix, prefix()}
+
+  @impl true
+  @spec down([down_option()]) :: :ok
+  def down(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    drop(index(:changes, [:transaction_id], prefix: prefix))
+
+    """
+    ALTER INDEX #{prefix}.changes_transaction_xact_id_index
+    RENAME TO changes_transaction_id_index;
+    """
+    |> squish_and_execute()
+
+    :ok
+  end
+end

--- a/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
+++ b/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
@@ -10,6 +10,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
     Carbonite.Migrations.up(4)
     Carbonite.Migrations.up(5)
     Carbonite.Migrations.up(6)
+    Carbonite.Migrations.up(7)
     Carbonite.Migrations.create_trigger(:rabbits)
     Carbonite.Migrations.put_trigger_config(:rabbits, :excluded_columns, ["age"])
     Carbonite.Migrations.put_trigger_config(:rabbits, :store_changed_from, true)
@@ -18,6 +19,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
 
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits)
+    Carbonite.Migrations.down(7)
     Carbonite.Migrations.down(6)
     Carbonite.Migrations.down(5)
     Carbonite.Migrations.down(4)

--- a/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
+++ b/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
@@ -10,6 +10,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
     Carbonite.Migrations.up(4, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.up(5, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.up(6, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(7, carbonite_prefix: "alternate_test_schema")
 
     Carbonite.Migrations.create_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
@@ -25,6 +26,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
+    Carbonite.Migrations.down(7, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.down(6, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.down(5, carbonite_prefix: "alternate_test_schema")
     Carbonite.Migrations.down(4, carbonite_prefix: "alternate_test_schema")


### PR DESCRIPTION
This patch adds migration V7 which adds an index on `changes.transaction_id`, necessary to keep `Carbonite.purge/2` operations performant.