### PR TITLE
[#93] Explictly name foreign key column in migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- Migration: Creating table `changes` failed when Ecto's `@migration_foreign_key` is set to `[column: <anything but id>]`.
+
 ## [0.11.0] - 2024-11-14
 
 **New migration patches:** 7

--- a/lib/carbonite/migrations/v1.ex
+++ b/lib/carbonite/migrations/v1.ex
@@ -169,6 +169,7 @@ defmodule Carbonite.Migrations.V1 do
         references(:transactions,
           on_delete: :delete_all,
           on_update: :update_all,
+          column: :id,
           type: :xid8,
           prefix: prefix
         ),


### PR DESCRIPTION
Fixes #93.