### PR TITLE
Mask filtered columns in changed_from.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+**New migration patches:** 8
+
+### Fixed
+
+- Make the trigger function correctly mask the `filtered_columns` in the `changed_from` JSON object if `store_changed_from` is set. (#96)
+
+⚠️ Unfortunately, this bug caused Carbonite to persist potentially sensitive data in the `changed_from` object even though they were listed in the `filtered_columns`. All users who combine `store_changed_from: true` with a `filtered_columns` setting should upgrade and assess the impact of this potential data leak.
+
 ## [0.11.1] - 2024-04-25
 
 ### Fixed

--- a/lib/carbonite/migrations/v8.ex
+++ b/lib/carbonite/migrations/v8.ex
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Carbonite.Migrations.V8 do
+  @moduledoc false
+
+  use Ecto.Migration
+  use Carbonite.Migrations.Version
+  alias Carbonite.Migrations.V6
+
+  @type prefix :: binary()
+
+  @type up_option :: {:carbonite_prefix, prefix()}
+
+  @spec create_capture_changes_procedure(prefix()) :: :ok
+  def create_capture_changes_procedure(prefix) do
+    """
+    CREATE OR REPLACE FUNCTION #{prefix}.capture_changes() RETURNS TRIGGER AS
+    $body$
+    DECLARE
+      trigger_row #{prefix}.triggers;
+      change_row #{prefix}.changes;
+      pk_source RECORD;
+      col_name VARCHAR;
+      pk_col_val VARCHAR;
+      old_value JSONB;
+    BEGIN
+      /* load trigger config */
+      SELECT *
+        INTO trigger_row
+        FROM #{prefix}.triggers
+        WHERE table_prefix = TG_TABLE_SCHEMA AND table_name = TG_TABLE_NAME;
+
+      IF
+        (trigger_row.mode = 'ignore' AND (trigger_row.override_xact_id IS NULL OR trigger_row.override_xact_id != pg_current_xact_id())) OR
+        (trigger_row.mode = 'capture' AND trigger_row.override_xact_id = pg_current_xact_id())
+      THEN
+        RETURN NULL;
+      END IF;
+
+      /* instantiate change row */
+      change_row = ROW(
+        NEXTVAL('#{prefix}.changes_id_seq'),
+        pg_current_xact_id(),
+        LOWER(TG_OP::TEXT),
+        TG_TABLE_SCHEMA::TEXT,
+        TG_TABLE_NAME::TEXT,
+        NULL,
+        NULL,
+        '{}',
+        NULL,
+        NULL
+      );
+
+      /* build table_pk */
+      IF trigger_row.primary_key_columns != '{}' THEN
+        IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+          pk_source := NEW;
+        ELSIF (TG_OP = 'DELETE') THEN
+          pk_source := OLD;
+        END IF;
+
+        change_row.table_pk := '{}';
+
+        FOREACH col_name IN ARRAY trigger_row.primary_key_columns LOOP
+          EXECUTE 'SELECT $1.' || col_name || '::TEXT' USING pk_source INTO pk_col_val;
+          change_row.table_pk := change_row.table_pk || pk_col_val;
+        END LOOP;
+      END IF;
+
+      /* fill in changed data */
+      IF (TG_OP = 'UPDATE') THEN
+        change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
+        change_row.changed_from = '{}'::JSONB;
+
+        FOR col_name, old_value
+        IN SELECT * FROM jsonb_each(to_jsonb(OLD.*) - trigger_row.excluded_columns)
+        LOOP
+          IF (change_row.data->col_name)::JSONB != old_value THEN
+            change_row.changed_from := jsonb_set(change_row.changed_from, ARRAY[col_name], old_value);
+          END IF;
+        END LOOP;
+
+        change_row.changed := ARRAY(SELECT jsonb_object_keys(change_row.changed_from));
+
+        IF change_row.changed = '{}' THEN
+          /* All changed fields are ignored. Skip this update. */
+          RETURN NULL;
+        END IF;
+
+        /* Persisting the old data is opt-in, discard if not configured. */
+        IF trigger_row.store_changed_from IS FALSE THEN
+          change_row.changed_from := NULL;
+        END IF;
+      ELSIF (TG_OP = 'DELETE') THEN
+        change_row.data = to_jsonb(OLD.*) - trigger_row.excluded_columns;
+      ELSIF (TG_OP = 'INSERT') THEN
+        change_row.data = to_jsonb(NEW.*) - trigger_row.excluded_columns;
+      END IF;
+
+      /* filtered columns */
+      FOREACH col_name IN ARRAY trigger_row.filtered_columns LOOP
+        change_row.data = jsonb_set(change_row.data, ('{' || col_name || '}')::TEXT[], jsonb('"[FILTERED]"'));
+
+        IF trigger_row.store_changed_from IS NOT NULL THEN
+          change_row.changed_from = jsonb_set(change_row.changed_from , ('{' || col_name || '}')::TEXT[], jsonb('"[FILTERED]"'));
+        END IF;
+      END LOOP;
+
+      /* insert, fail gracefully unless transaction record present or NEXTVAL has never been called */
+      BEGIN
+        change_row.transaction_id = CURRVAL('#{prefix}.transactions_id_seq');
+
+        /* verify that xact_id matches */
+        IF NOT
+          EXISTS(
+            SELECT 1 FROM #{prefix}.transactions
+            WHERE id = change_row.transaction_id AND xact_id = change_row.transaction_xact_id
+          )
+        THEN
+          RAISE USING ERRCODE = 'foreign_key_violation';
+        END IF;
+
+        INSERT INTO #{prefix}.changes VALUES (change_row.*);
+      EXCEPTION WHEN foreign_key_violation OR object_not_in_prerequisite_state THEN
+          RAISE '% on table %.% without prior INSERT into #{prefix}.transactions',
+            TG_OP, TG_TABLE_SCHEMA, TG_TABLE_NAME USING ERRCODE = 'foreign_key_violation';
+      END;
+
+      RETURN NULL;
+    END;
+    $body$
+    LANGUAGE plpgsql;
+    """
+    |> squish_and_execute()
+
+    :ok
+  end
+
+  @impl true
+  @spec up([up_option()]) :: :ok
+  def up(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    create_capture_changes_procedure(prefix)
+
+    :ok
+  end
+
+  @type down_option :: {:carbonite_prefix, prefix()}
+
+  @impl true
+  @spec down([down_option()]) :: :ok
+  def down(opts) do
+    prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+
+    V6.create_capture_changes_procedure(prefix)
+
+    :ok
+  end
+end

--- a/test/capture_test.exs
+++ b/test/capture_test.exs
@@ -387,5 +387,22 @@ defmodule CaptureTest do
 
       assert [%{"data" => %{"name" => "[FILTERED]"}}] = select_changes()
     end
+
+    test "appear as [FILTERED] in the changed_from" do
+      TestRepo.transaction(fn ->
+        query!("""
+        UPDATE carbonite_default.triggers SET filtered_columns = '{name}';
+        """)
+
+        insert_transaction()
+        insert_jack()
+        query!("UPDATE rabbits SET name = 'Jane' WHERE name = 'Jack';")
+      end)
+
+      assert [
+               _insert,
+               %{"changed_from" => %{"name" => "[FILTERED]"}}
+             ] = select_changes()
+    end
   end
 end

--- a/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
+++ b/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
@@ -11,6 +11,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
     Carbonite.Migrations.up(5)
     Carbonite.Migrations.up(6)
     Carbonite.Migrations.up(7)
+    Carbonite.Migrations.up(8)
     Carbonite.Migrations.create_trigger(:rabbits)
     Carbonite.Migrations.put_trigger_config(:rabbits, :excluded_columns, ["age"])
     Carbonite.Migrations.put_trigger_config(:rabbits, :store_changed_from, true)
@@ -19,6 +20,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
 
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits)
+    Carbonite.Migrations.down(8)
     Carbonite.Migrations.down(7)
     Carbonite.Migrations.down(6)
     Carbonite.Migrations.down(5)

--- a/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
+++ b/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
@@ -4,7 +4,7 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
   use Ecto.Migration
 
   def up do
-    Carbonite.Migrations.up(1..7, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.up(1..8, carbonite_prefix: "alternate_test_schema")
 
     Carbonite.Migrations.create_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
@@ -20,6 +20,6 @@ defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
   def down do
     Carbonite.Migrations.drop_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
-    Carbonite.Migrations.down(7..1, carbonite_prefix: "alternate_test_schema")
+    Carbonite.Migrations.down(8..1, carbonite_prefix: "alternate_test_schema")
   end
 end


### PR DESCRIPTION
This patch extends the `filtered_column` mechanism in the capture trigger to cover the `changed_from` object alongside the `data`.

Fixes #96.