### PR TITLE
Replace override_xact_id with local variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**New migration patches:** 10
+
+### Fixed
+
+- Improve performance of test setups by using a transaction-local variable in `override_mode/2` . The previous implementation could cause parallel tests to wait for row locks on the `triggers` table.
+
 ## [0.13.0] - 2024-06-27
 
 **New migration patches:** 9

--- a/README.md
+++ b/README.md
@@ -444,7 +444,14 @@ Carbonite.purge(MyApp.Repo)
 
 One of Carbonite's key features is that it is virtually impossible to forget to record a change to a table (due to the trigger) or to forget to insert an enclosing `Carbonite.Transaction` beforehand (due to the foreign key constraint between `changes` and `transactions`). However, in some circumstances it may be desirable to temporarily switch off change capturing. One such situation is the use of factories (e.g. ExMachina) inside your test suite: Inserting a transaction before each factory call quickly becomes cumbersome and will unnecessarily increase execution time. Additionally, the use of Ecto's SQL sandbox means that your factory calls are contained in the same transaction as your domain logic, which means you cannot simply insert a `Carbonite.Transaction` before your factories if you intend to assert on the one inserted by your domain logic.
 
-To bypass the capture trigger, Carbonite's trigger configuration provides a toggle mechanism consisting of two fields: `mode` and `override_xact_id`. The former you set while installing the trigger on a table in a migration, while the latter allows to "override" whatever has been set, at runtime and only for the current transaction. If you are using Ecto's SQL sandbox for running transactional tests, this means the override is going to be active until the end of the test case.
+To bypass the capture trigger, Carbonite's trigger configuration provides a
+toggle mechanism consisting of two factors: the `triggers.mode` field defining
+the default mode and the `Carbonite.override_mode/2` function. The former you
+set while installing the trigger on a table in a migration, while the latter
+allows to "override" whatever has been set, at runtime and limited to the current
+transaction. If you are using Ecto's SQL sandbox for running transactional
+tests, this means the override is going to be active until the end of the test
+case.
 
 As a result, you have two options:
 

--- a/lib/carbonite.ex
+++ b/lib/carbonite.ex
@@ -13,7 +13,6 @@ defmodule Carbonite do
 
   @moduledoc since: "0.1.0"
 
-  import Ecto.Query
   alias Carbonite.{Outbox, Prefix, Query, Schema, Transaction, Trigger}
   require Prefix
   require Schema
@@ -120,31 +119,19 @@ defmodule Carbonite do
 
   ## Options
 
-  * `to` - allows to specify the target mode, useful to reset the mode after use
+  * `to` - allows to specify the target mode
   * `carbonite_prefix` - defines the audit trail's schema, defaults to `"carbonite_default"`
   """
   @doc since: "0.4.0"
   @spec override_mode(repo()) :: :ok
   @spec override_mode(repo(), [{:to, Trigger.mode()} | prefix_option()]) :: :ok
   def override_mode(repo, opts \\ []) do
-    opts
-    |> Keyword.take([:carbonite_prefix])
-    |> Query.triggers()
-    |> update([], set: [override_xact_id: ^override_xact_id(opts)])
-    |> repo.update_all([])
+    carbonite_prefix = Keyword.get(opts, :carbonite_prefix, default_prefix())
+    mode = Keyword.get(opts, :to, :override)
+
+    repo.query!("SET LOCAL #{carbonite_prefix}.override_mode = '#{mode}';")
 
     :ok
-  end
-
-  defp override_xact_id(opts) do
-    if mode = Keyword.get(opts, :to) do
-      dynamic(
-        [],
-        fragment("CASE WHEN mode != ? THEN pg_current_xact_id() ELSE NULL END", ^to_string(mode))
-      )
-    else
-      dynamic([], fragment("pg_current_xact_id()"))
-    end
   end
 
   @type process_option ::

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations do
   # --------------------------------- patch levels ---------------------------------
 
   @initial_patch 1
-  @current_patch 9
+  @current_patch 10
 
   @doc false
   @spec initial_patch :: non_neg_integer()
@@ -27,6 +27,10 @@ defmodule Carbonite.Migrations do
   @doc false
   @spec current_patch :: non_neg_integer()
   def current_patch, do: @current_patch
+
+  @doc false
+  @spec patch_range :: Range.t()
+  def patch_range, do: @initial_patch..@current_patch
 
   # --------------------------------- main schema ----------------------------------
 

--- a/lib/carbonite/migrations/v1.ex
+++ b/lib/carbonite/migrations/v1.ex
@@ -120,6 +120,27 @@ defmodule Carbonite.Migrations.V1 do
     |> squish_and_execute()
   end
 
+  @spec create_triggers_table_index(prefix()) :: :ok
+  @spec create_triggers_table_index(prefix(), atom()) :: :ok
+  def create_triggers_table_index(prefix, override_transaction_id \\ :override_transaction_id) do
+    create(
+      index("triggers", [:table_prefix, :table_name],
+        name: "table_index",
+        unique: true,
+        include: [
+          :primary_key_columns,
+          :excluded_columns,
+          :filtered_columns,
+          :mode,
+          override_transaction_id
+        ],
+        prefix: prefix
+      )
+    )
+
+    :ok
+  end
+
   @impl true
   @spec up([up_option()]) :: :ok
   def up(opts) do
@@ -204,20 +225,7 @@ defmodule Carbonite.Migrations.V1 do
       timestamps()
     end
 
-    create(
-      index("triggers", [:table_prefix, :table_name],
-        name: "table_index",
-        unique: true,
-        include: [
-          :primary_key_columns,
-          :excluded_columns,
-          :filtered_columns,
-          :mode,
-          :override_transaction_id
-        ],
-        prefix: prefix
-      )
-    )
+    create_triggers_table_index(prefix)
 
     # ------------- Capture Function -------------
 

--- a/lib/carbonite/trigger.ex
+++ b/lib/carbonite/trigger.ex
@@ -23,7 +23,6 @@ defmodule Carbonite.Trigger do
           filtered_columns: [String.t()],
           store_changed_from: boolean(),
           mode: mode(),
-          override_xact_id: nil | non_neg_integer(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -36,7 +35,6 @@ defmodule Carbonite.Trigger do
     field(:filtered_columns, {:array, :string})
     field(:store_changed_from, :boolean)
     field(:mode, Ecto.Enum, values: [:capture, :ignore])
-    field(:override_xact_id, :integer)
 
     timestamps()
   end

--- a/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
+++ b/test/support/test_repo/migrations/20210704201627_install_carbonite.exs
@@ -2,31 +2,18 @@
 
 defmodule Carbonite.TestRepo.Migrations.InstallCarbonite do
   use Ecto.Migration
+  alias Carbonite.Migrations, as: M
 
   def up do
-    Carbonite.Migrations.up(1)
-    Carbonite.Migrations.up(2)
-    Carbonite.Migrations.up(3)
-    Carbonite.Migrations.up(4)
-    Carbonite.Migrations.up(5)
-    Carbonite.Migrations.up(6)
-    Carbonite.Migrations.up(7)
-    Carbonite.Migrations.up(8)
-    Carbonite.Migrations.create_trigger(:rabbits)
-    Carbonite.Migrations.put_trigger_config(:rabbits, :excluded_columns, ["age"])
-    Carbonite.Migrations.put_trigger_config(:rabbits, :store_changed_from, true)
-    Carbonite.Migrations.create_outbox("rabbits")
+    M.up(M.patch_range())
+    M.create_trigger(:rabbits)
+    M.put_trigger_config(:rabbits, :excluded_columns, ["age"])
+    M.put_trigger_config(:rabbits, :store_changed_from, true)
+    M.create_outbox("rabbits")
   end
 
   def down do
-    Carbonite.Migrations.drop_trigger(:rabbits)
-    Carbonite.Migrations.down(8)
-    Carbonite.Migrations.down(7)
-    Carbonite.Migrations.down(6)
-    Carbonite.Migrations.down(5)
-    Carbonite.Migrations.down(4)
-    Carbonite.Migrations.down(3)
-    Carbonite.Migrations.down(2)
-    Carbonite.Migrations.down(1)
+    M.drop_trigger(:rabbits)
+    M.down(Enum.reverse(M.patch_range()))
   end
 end

--- a/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
+++ b/test/support/test_repo/migrations/20221011201645_install_carbonite_alternate_test_schema.exs
@@ -2,24 +2,23 @@
 
 defmodule Carbonite.TestRepo.Migrations.InstallCarboniteAlternateTestSchema do
   use Ecto.Migration
+  alias Carbonite.Migrations, as: M
 
   def up do
-    Carbonite.Migrations.up(1..8, carbonite_prefix: "alternate_test_schema")
+    M.up(M.patch_range(), carbonite_prefix: "alternate_test_schema")
 
-    Carbonite.Migrations.create_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
+    M.create_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
-    Carbonite.Migrations.put_trigger_config(:rabbits, :mode, :ignore,
-      carbonite_prefix: "alternate_test_schema"
-    )
+    M.put_trigger_config(:rabbits, :mode, :ignore, carbonite_prefix: "alternate_test_schema")
 
-    Carbonite.Migrations.create_outbox("alternate_outbox",
+    M.create_outbox("alternate_outbox",
       carbonite_prefix: "alternate_test_schema"
     )
   end
 
   def down do
-    Carbonite.Migrations.drop_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
+    M.drop_trigger(:rabbits, carbonite_prefix: "alternate_test_schema")
 
-    Carbonite.Migrations.down(8..1, carbonite_prefix: "alternate_test_schema")
+    M.down(Enum.reverse(M.patch_range()), carbonite_prefix: "alternate_test_schema")
   end
 end


### PR DESCRIPTION
This patch drops the `triggers.override_xact_id` column in favor of a transaction-local variable. This should improve test performance for projects making heavy use of `override_mode/2` in tests, as the previous code would acquire row locks on the `triggers`.

For instance, the test setup most badly affected by this would be:

* Ecto's sandbox, i.e. the entire test runs in a transaction
* Default to `capture` mode
* Use `override_mode/2` to temporarily set to ignore for factory calls

The new code uses `SET LOCAL` to set a variable instead without any locks.

- Drive-by: Fix #85 