### PR TITLE
Replace calls to Ecto.Migration.timestamps/{0,1} with `add/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Improve performance of test setups by using a transaction-local variable in `override_mode/2` . The previous implementation could cause parallel tests to wait for row locks on the `triggers` table.
+- Replaced calls to `Ecto.Migration.timestamps/1` in migrations with explicit `add(:inserted_at, ...)` calls. This ensures that we don't be affected by users' `@migration_timestamps` options.
 
 ## [0.13.0] - 2024-06-27
 

--- a/lib/carbonite/migrations/v1.ex
+++ b/lib/carbonite/migrations/v1.ex
@@ -156,8 +156,7 @@ defmodule Carbonite.Migrations.V1 do
       add(:id, :xid8, null: false, primary_key: true)
       add(:meta, :map, null: false, default: %{})
       add(:processed_at, :utc_datetime_usec)
-
-      timestamps(updated_at: false, type: :utc_datetime_usec)
+      add(:inserted_at, :utc_datetime_usec, null: false)
     end
 
     create(
@@ -221,8 +220,8 @@ defmodule Carbonite.Migrations.V1 do
       add(:filtered_columns, {:array, :string}, null: false)
       add(:mode, :"#{prefix}.trigger_mode", null: false)
       add(:override_transaction_id, :xid8, null: true)
-
-      timestamps()
+      add(:inserted_at, :utc_datetime_usec, null: false)
+      add(:updated_at, :utc_datetime_usec, null: false)
     end
 
     create_triggers_table_index(prefix)

--- a/lib/carbonite/migrations/v3.ex
+++ b/lib/carbonite/migrations/v3.ex
@@ -19,8 +19,8 @@ defmodule Carbonite.Migrations.V3 do
       add(:name, :string, null: false, primary_key: true)
       add(:memo, :map, null: false, default: "{}")
       add(:last_transaction_id, :xid8, null: false, default: "0")
-
-      timestamps(type: :utc_datetime_usec)
+      add(:inserted_at, :utc_datetime_usec, null: false)
+      add(:updated_at, :utc_datetime_usec, null: false)
     end
 
     alter table("transactions", prefix: prefix) do


### PR DESCRIPTION
Fixes #108