### PR TITLE
Update reference to deprecated `put_trigger_option`

### DIFF
--- a/lib/mix/tasks/carbonite.gen.initial_migration.ex
+++ b/lib/mix/tasks/carbonite.gen.initial_migration.ex
@@ -59,10 +59,10 @@ defmodule Mix.Tasks.Carbonite.Gen.InitialMigration do
 
       # Configure trigger options:
       #
-      #    Carbonite.Migrations.put_trigger_option("rabbits", :primary_key_columns, ["compound", "key"])
-      #    Carbonite.Migrations.put_trigger_option("rabbits", :excluded_columns, ["private"])
-      #    Carbonite.Migrations.put_trigger_option("rabbits", :filtered_columns, ["private"])
-      #    Carbonite.Migrations.put_trigger_option("rabbits", :mode, :ignore)
+      #    Carbonite.Migrations.put_trigger_config("rabbits", :primary_key_columns, ["compound", "key"])
+      #    Carbonite.Migrations.put_trigger_config("rabbits", :excluded_columns, ["private"])
+      #    Carbonite.Migrations.put_trigger_config("rabbits", :filtered_columns, ["private"])
+      #    Carbonite.Migrations.put_trigger_config("rabbits", :mode, :ignore)
 
       # If you wish to insert an initial outbox:
       #


### PR DESCRIPTION
Seems that `Carbonite.Migrations.put_trigger_option` is no longer available, but is still referenced in the generated migration file. I've changed it to `Carbonite.Migrations.put_trigger_config`.