### PR TITLE
[#121] Handle null rows in triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- Better error handling when the trigger record is non-existent.
+
 ## [0.15.0] - 2025-01-01
 
 ### Fixed

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -18,7 +18,7 @@ defmodule Carbonite.Migrations do
   # --------------------------------- patch levels ---------------------------------
 
   @initial_patch 1
-  @current_patch 11
+  @current_patch 12
 
   @doc false
   @spec initial_patch :: non_neg_integer()

--- a/test/capture_test.exs
+++ b/test/capture_test.exs
@@ -438,4 +438,19 @@ defmodule CaptureTest do
       assert [%{"op" => "insert"}] = select_changes()
     end
   end
+
+  test "missing trigger row lets the trigger function error gracefully" do
+    msg =
+      "ERROR P0002 (no_data_found) (carbonite) INSERT on table public.rabbits " <>
+        "but no trigger record in carbonite_default.triggers"
+
+    TestRepo.transaction(fn ->
+      insert_transaction()
+      query!("DELETE FROM carbonite_default.triggers;")
+
+      assert_raise Postgrex.Error, msg, fn ->
+        insert_jack()
+      end
+    end)
+  end
 end


### PR DESCRIPTION
When the trigger query returns null, we currently fail with a rather obscure

```
** (Postgrex.Error) ERROR 23502 (not_null_violation) null value in column "data" of relation "changes" violates not-null constraint

         table: changes
         column: data
```

That is because Postgres propagates the null value when the second argument to the `- (jsonb, text[])` operator is null`.

```
-- returns null
select '{}'::jsonb - NULL;
```

This patch handles this case explicitly and raises a better error message.

Fixes #121 