### PR TITLE
[#136] Enable built-in JSON support

### DIFF
--- a/lib/carbonite/change.ex
+++ b/lib/carbonite/change.ex
@@ -19,18 +19,23 @@ defmodule Carbonite.Change do
 
   use Carbonite.Schema
 
-  if Code.ensure_loaded?(Jason.Encoder) do
-    @derive {Jason.Encoder,
-             only: [
-               :id,
-               :op,
-               :table_prefix,
-               :table_name,
-               :table_pk,
-               :data,
-               :changed,
-               :changed_from
-             ]}
+  @encodable_columns [
+    :id,
+    :op,
+    :table_prefix,
+    :table_name,
+    :table_pk,
+    :data,
+    :changed,
+    :changed_from
+  ]
+
+  if Code.ensure_loaded?(JSON) do
+    @derive {JSON.Encoder, only: @encodable_columns}
+  else
+    if Code.ensure_loaded?(Jason.Encoder) do
+      @derive {Jason.Encoder, only: @encodable_columns}
+    end
   end
 
   @primary_key false

--- a/lib/carbonite/migrations.ex
+++ b/lib/carbonite/migrations.ex
@@ -11,6 +11,8 @@ defmodule Carbonite.Migrations do
   import Carbonite.Migrations.Helper
   import Carbonite.Prefix
 
+  @json_module if Code.ensure_loaded?(JSON), do: JSON, else: Jason
+
   @type patch :: non_neg_integer()
   @type prefix :: binary()
   @type table_name :: binary() | atom()
@@ -373,7 +375,7 @@ defmodule Carbonite.Migrations do
     meta =
       %{type: "migration", direction: direction(), name: to_string(name)}
       |> Map.merge(meta)
-      |> Jason.encode!()
+      |> @json_module.encode!()
 
     statement =
       """

--- a/lib/carbonite/transaction.ex
+++ b/lib/carbonite/transaction.ex
@@ -12,8 +12,14 @@ defmodule Carbonite.Transaction do
   use Carbonite.Schema
   import Ecto.Changeset
 
-  if Code.ensure_loaded?(Jason.Encoder) do
-    @derive {Jason.Encoder, only: [:id, :meta, :inserted_at, :changes]}
+  @encodable_columns [:id, :meta, :inserted_at, :changes]
+
+  if Code.ensure_loaded?(JSON) do
+    @derive {JSON.Encoder, only: @encodable_columns}
+  else
+    if Code.ensure_loaded?(Jason.Encoder) do
+      @derive {Jason.Encoder, only: @encodable_columns}
+    end
   end
 
   @primary_key false

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Carbonite.MixProject do
   defp deps do
     [
       {:ecto_sql, "~> 3.10"},
-      {:jason, "~> 1.2"},
+      {:jason, "~> 1.2", optional: true},
       {:postgrex, "~> 0.15 and >= 0.15.11"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/test/carbonite/change_test.exs
+++ b/test/carbonite/change_test.exs
@@ -4,7 +4,9 @@ defmodule Carbonite.ChangeTest do
   use Carbonite.APICase, async: true
   alias Carbonite.Change
 
-  describe "Jason.Encoder implementation" do
+  @json_module if Code.ensure_loaded?(JSON), do: JSON, else: Jason
+
+  describe "JSON Encoder implementation" do
     test "Carbonite.Change can be encoded to JSON" do
       json =
         %Change{
@@ -17,8 +19,8 @@ defmodule Carbonite.ChangeTest do
           changed: ["name"],
           changed_from: %{"name" => "Jane"}
         }
-        |> Jason.encode!()
-        |> Jason.decode!()
+        |> @json_module.encode!()
+        |> @json_module.decode!()
 
       assert json ==
                %{

--- a/test/carbonite/transaction_test.exs
+++ b/test/carbonite/transaction_test.exs
@@ -5,6 +5,8 @@ defmodule Carbonite.TransactionTest do
   import Carbonite.Transaction
   alias Carbonite.{Change, Transaction}
 
+  @json_module if Code.ensure_loaded?(JSON), do: JSON, else: Jason
+
   describe "changeset/1" do
     test "transaction_changesets an Ecto.Changeset for a transaction" do
       %Ecto.Changeset{} = changeset = changeset()
@@ -27,7 +29,7 @@ defmodule Carbonite.TransactionTest do
     end
   end
 
-  describe "Jason.Encoder implementation" do
+  describe "JSON encoder implementation" do
     test "Transaction can be encoded to JSON" do
       json =
         %Transaction{
@@ -47,8 +49,8 @@ defmodule Carbonite.TransactionTest do
             }
           ]
         }
-        |> Jason.encode!()
-        |> Jason.decode!()
+        |> @json_module.encode!()
+        |> @json_module.decode!()
 
       assert json ==
                %{


### PR DESCRIPTION
Implements #136 

Adds built-in support for JSON for Elixir versions 1.18+. As requested, `jason` is still available to support older versions of Elixir. `json` is given precedence over `jason`, assuming `json` doesn't exist, it will attempt to use `jason` as before.
