### PR TITLE
Include custom carbonite prefix in multi step name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Allow to set the `last_transaction_id` when outbox is created
 - Accept Ecto `dynamic/2` expressions for the `:filter` option on `Carbonite.process/4`.
 
+### Changed
+
+- Multi steps build by `Carbonite.Multi.insert_transaction/3` are now called `{:carbonite_transactions, <prefix>}`
+  when the `:carbonite_prefix` option is given to allow inserting transactions into multiple prefixes in one multi.
+
 ## [0.15.2] - 2025-07-15
 
 ### Added

--- a/lib/carbonite/multi.ex
+++ b/lib/carbonite/multi.ex
@@ -33,7 +33,14 @@ defmodule Carbonite.Multi do
   @spec insert_transaction(Multi.t(), params()) :: Multi.t()
   @spec insert_transaction(Multi.t(), params(), [prefix_option()]) :: Multi.t()
   def insert_transaction(%Multi{} = multi, params \\ %{}, opts \\ []) do
-    Multi.run(multi, :carbonite_transaction, fn repo, _state ->
+    name =
+      if carbonite_prefix = Keyword.get(opts, :carbonite_prefix) do
+        {:carbonite_transaction, carbonite_prefix}
+      else
+        :carbonite_transaction
+      end
+
+    Multi.run(multi, name, fn repo, _state ->
       Carbonite.insert_transaction(repo, params, opts)
     end)
   end

--- a/test/carbonite/multi_test.exs
+++ b/test/carbonite/multi_test.exs
@@ -14,6 +14,14 @@ defmodule Carbonite.MultiTest do
                |> Ecto.Multi.insert(:rabbit, &Rabbit.create_changeset(&1.params))
                |> TestRepo.transaction()
     end
+
+    test "operation names include the given prefix option" do
+      assert %Ecto.Multi{operations: [{:carbonite_transaction, _}]} =
+               insert_transaction(Ecto.Multi.new())
+
+      assert %Ecto.Multi{operations: [{{:carbonite_transaction, "custom"}, _}]} =
+               insert_transaction(Ecto.Multi.new(), %{}, carbonite_prefix: "custom")
+    end
   end
 
   describe "override_mode/2" do


### PR DESCRIPTION
This patch changes behaviour of `Carbonite.Multi.insert_transaction/3` to include the given `:carbonite_prefix` option in the multi name. This allows for multi-stream setups on the same DB transaction, e.g.

```
Multi.new()
|> Carbonite.Multi.insert_transaction(%{type: "foo"})
|> Carbonite.Multi.insert_transaction(%{type: "foo"}, carbonite_prefix: "my_other_audits")
```