### PR TITLE
Add Carbonite.delete_transaction_if_empty/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow to set the `last_transaction_id` when outbox is created
 - Accept Ecto `dynamic/2` expressions for the `:filter` option on `Carbonite.process/4`.
+- New `Carbonite.delete_transaction_if_empty/2` deletes the current transaction if no changes have been recorded.
 
 ### Changed
 

--- a/test/carbonite/query_test.exs
+++ b/test/carbonite/query_test.exs
@@ -77,6 +77,16 @@ defmodule Carbonite.QueryTest do
     end
   end
 
+  describe "without_changes/1" do
+    setup [:insert_past_transactions, :insert_rabbits]
+
+    test "filters a transaction query for orphans" do
+      # Rabbit transaction has changes, past transactions don't.
+      assert length(TestRepo.all(Query.transactions())) == 4
+      assert length(TestRepo.all(Query.without_changes(Query.transactions()))) == 3
+    end
+  end
+
   describe "outbox/1" do
     defp outbox(name) do
       name


### PR DESCRIPTION
This patch adds a new `Carbonite.delete_transaction_if_empty/2` function that deletes the ongoing transaction if no changes have been recorded.

I'm a bit torn on this one, as advertising this as the "go to solution" to avoid orphaned transactions is probably uncalled for. For example, my employer has an operation in their codebase that 99% of the time does nothing, but in 1% of runs it requires a transaction; and the operation runs frequently enough for it to matter, so adding a pointless `INSERT` + `DELETE` combo is likely not ideal. However, in other cases I've found this trade-off to be less clear, as "skip the entire transaction" often hurts code clarity more (e.g. as it requires pulling up conditionals from lower layers).