### PR TITLE
Include custom carbonite prefix in remaining multi step names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Changed
+
+- Multi steps built by `Carbonite.Multi.fetch_changes/2` and `Carbonite.Multi.override_mode/2` are now called
+  `{:carbonite_changes, <prefix>}` and `{:carbonite_triggers, <prefix>}` respectively when the `:carbonite_prefix`
+  option is given, extending the multi-stream support introduced in 0.16.0 to the remaining `Carbonite.Multi` functions.
+
 ## [0.16.0] - 2025-09-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Multi steps built by `Carbonite.Multi.fetch_changes/2` and `Carbonite.Multi.override_mode/2` are now called
   `{:carbonite_changes, <prefix>}` and `{:carbonite_triggers, <prefix>}` respectively when the `:carbonite_prefix`
-  option is given, extending the multi-stream support introduced in 0.16.0 to the remaining `Carbonite.Multi` functions.
+  option is given, extending the multi-stream support introduced in 0.16.0 to the remaining `Carbonite.Multi` functions. (@Hedde)
 
 ## [0.16.0] - 2025-09-10
 

--- a/lib/carbonite/multi.ex
+++ b/lib/carbonite/multi.ex
@@ -69,7 +69,8 @@ defmodule Carbonite.Multi do
 
   Useful for returning all transaction changes to the caller.
 
-  Multi step is called `:carbonite_changes`.
+  Multi step is called `:carbonite_changes` if no `:carbonite_prefix` option
+  is given, otherwise `{:carbonite_changes, <prefix>}`.
 
   See `Carbonite.fetch_changes/2` for options.
 
@@ -84,7 +85,7 @@ defmodule Carbonite.Multi do
   @spec fetch_changes(Multi.t()) :: Multi.t()
   @spec fetch_changes(Multi.t(), [prefix_option()]) :: Multi.t()
   def fetch_changes(%Multi{} = multi, opts \\ []) do
-    Multi.run(multi, :carbonite_changes, fn repo, _state ->
+    Multi.run(multi, maybe_with_prefix(:carbonite_changes, opts), fn repo, _state ->
       Carbonite.fetch_changes(repo, opts)
     end)
   end
@@ -92,13 +93,16 @@ defmodule Carbonite.Multi do
   @doc """
   Sets the current transaction to "override mode" for all tables in the audit log.
 
+  Multi step is called `:carbonite_triggers` if no `:carbonite_prefix` option
+  is given, otherwise `{:carbonite_triggers, <prefix>}`.
+
   See `Carbonite.override_mode/2` for options.
   """
   @doc since: "0.2.0"
   @spec override_mode(Multi.t()) :: Multi.t()
   @spec override_mode(Multi.t(), [{:to, Trigger.mode()} | prefix_option()]) :: Multi.t()
   def override_mode(%Multi{} = multi, opts \\ []) do
-    Multi.run(multi, :carbonite_triggers, fn repo, _state ->
+    Multi.run(multi, maybe_with_prefix(:carbonite_triggers, opts), fn repo, _state ->
       {:ok, Carbonite.override_mode(repo, opts)}
     end)
   end

--- a/test/carbonite/multi_test.exs
+++ b/test/carbonite/multi_test.exs
@@ -44,6 +44,16 @@ defmodule Carbonite.MultiTest do
     end
   end
 
+  describe "fetch_changes/2" do
+    test "operation names include the given prefix option" do
+      assert %Ecto.Multi{operations: [{:carbonite_changes, _}]} =
+               fetch_changes(Ecto.Multi.new())
+
+      assert %Ecto.Multi{operations: [{{:carbonite_changes, "custom"}, _}]} =
+               fetch_changes(Ecto.Multi.new(), carbonite_prefix: "custom")
+    end
+  end
+
   describe "override_mode/2" do
     test "enables override mode for the current transaction" do
       assert {:ok, _} =
@@ -52,6 +62,14 @@ defmodule Carbonite.MultiTest do
                |> Ecto.Multi.put(:params, %{name: "Jack", age: 99})
                |> Ecto.Multi.insert(:rabbit, &Rabbit.create_changeset(&1.params))
                |> TestRepo.transaction()
+    end
+
+    test "operation names include the given prefix option" do
+      assert %Ecto.Multi{operations: [{:carbonite_triggers, _}]} =
+               override_mode(Ecto.Multi.new())
+
+      assert %Ecto.Multi{operations: [{{:carbonite_triggers, "custom"}, _}]} =
+               override_mode(Ecto.Multi.new(), carbonite_prefix: "custom")
     end
   end
 end


### PR DESCRIPTION
Follows up on #143 — closes #147.

Extends the prefixed step-name behaviour introduced in #143 to the remaining
`Carbonite.Multi` functions: `fetch_changes/2` and `override_mode/2` now also
include the `:carbonite_prefix` option in their multi step name. Without this,
combining these functions with different prefixes in one `Ecto.Multi` raises
because of a duplicate step name.

    Multi.new()
    |> Carbonite.Multi.insert_transaction(%{type: "foo"})
    |> Carbonite.Multi.fetch_changes()
    |> Carbonite.Multi.insert_transaction(%{type: "foo"}, carbonite_prefix: "my_other_audits")
    |> Carbonite.Multi.fetch_changes(carbonite_prefix: "my_other_audits")

Changes:

- `fetch_changes/2` step is `{:carbonite_changes, <prefix>}` when `:carbonite_prefix` is given
- `override_mode/2` step is `{:carbonite_triggers, <prefix>}` when `:carbonite_prefix` is given
- Matching "operation names include the given prefix option" tests
- CHANGELOG entry under Unreleased